### PR TITLE
Randomise the order of tests execution

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py33, py34, py35, py36, docs
 deps =
     coverage
     pytest
+    pytest-random-order
     mock
     flake8
 commands =


### PR DESCRIPTION
Apparently pytest sorts tests before execution so anyone anywhere get
the same execution order. While this may be good in one cases, it has
its drawbacks in others. Having the same execution order between runs
means that we may loose control of tests isolation, i.e. one test may
mistakenly depend on artifacts provided by the other. In order to prove
tests isolation it's a common practice to randomise execution order.