### PR TITLE
Use dict syntax to access document properties

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -410,13 +410,13 @@ class Holocron(object):
             when = options.pop('when', None)
 
             for document in iterdocuments(documents, when):
-                meta, document.content = converter.to_html(document.content)
-                document.destination = \
-                    os.path.splitext(document.destination)[0] + '.html'
+                meta, document['content'] = \
+                    converter.to_html(document['content'])
+                document['destination'] = \
+                    os.path.splitext(document['destination'])[0] + '.html'
 
                 for key, value in meta.items():
-                    if not hasattr(document, key):
-                        setattr(document, key, value)
+                    document.setdefault(key, value)
 
             return documents
 

--- a/holocron/content.py
+++ b/holocron/content.py
@@ -9,6 +9,7 @@
 """
 
 import os
+import warnings
 
 
 class Document(dict):
@@ -26,6 +27,9 @@ class Document(dict):
 
     def __getattr__(self, attr):
         try:
+            warnings.warn(
+                "Attributes are deprecated way to retrieve data out of "
+                "documents, please use dict syntax instead.")
             return self[attr]
         except KeyError as exc:
             raise AttributeError(str(exc))
@@ -80,7 +84,8 @@ class Page(Document):
     def __init__(self, *args, **kwargs):
         super(Page, self).__init__(*args, **kwargs)
 
-        self.author = self._app.conf['site.author']
+        self['author'] = self._app.conf['site.author']
+        self['template'] = self.template
 
 
 class Post(Page):

--- a/holocron/ext/processors/_misc.py
+++ b/holocron/ext/processors/_misc.py
@@ -6,7 +6,7 @@ import re
 _evaluators = {
     'match':
         lambda attribute, pattern, document: (
-            bool(re.match(pattern, getattr(document, attribute)))
+            bool(re.match(pattern, document[attribute]))
         ),
 }
 

--- a/holocron/ext/processors/atom.py
+++ b/holocron/ext/processors/atom.py
@@ -58,7 +58,7 @@ def process(app, documents, **options):
     # In order to speed up feed fetching and decrease amount of traffic to
     # deliver its content the feed is usually limited to "N" latest posts
     # where "N" is passed as option.
-    selected = sorted(selected, key=lambda d: d.published, reverse=True)
+    selected = sorted(selected, key=lambda d: d['published'], reverse=True)
     selected = selected[:posts_number]
 
     # These two lines will be gone once state mechanism is implemented to
@@ -68,7 +68,7 @@ def process(app, documents, **options):
 
     # Produce a virtual document with Feed.
     feed = content.Document(app)
-    feed.content = _template.render(
+    feed['content'] = _template.render(
         documents=selected,
         siteurl_self=url,
         siteurl_alt=app.conf['site.url'],
@@ -77,7 +77,7 @@ def process(app, documents, **options):
         site=app.conf['site'],
         date=datetime.datetime.utcnow().replace(microsecond=0),
         encoding=encoding)
-    feed.source = 'virtual://feed'
-    feed.destination = save_as
+    feed['source'] = 'virtual://feed'
+    feed['destination'] = save_as
 
     return documents + [feed]

--- a/holocron/ext/processors/commit.py
+++ b/holocron/ext/processors/commit.py
@@ -18,16 +18,16 @@ def process(app, documents, **options):
     for document in iterdocuments(list(documents), when):
         to_remove.append(document)
 
-        destination = os.path.join(path, document.destination)
+        destination = os.path.join(path, document['destination'])
         if not os.path.exists(os.path.dirname(destination)):
             os.makedirs(os.path.dirname(destination))
 
         # Once Jinja2 is a standalone processor, these lines will be gone.
         if isinstance(document, content.Page):
-            template = app.jinja_env.get_template(document.template)
-            document.content = template.render(document=document)
+            template = app.jinja_env.get_template(document['template'])
+            document['content'] = template.render(document=document)
 
-        if isinstance(document.content, str):
+        if isinstance(document['content'], str):
             # A document may suggest its own encoding as it might be pretty
             # important to have this one. One of such examples is sitemap.xml
             # which must be a UTF-8 encoded by design.
@@ -37,7 +37,7 @@ def process(app, documents, **options):
             output = open(destination, 'wb')
 
         with output:
-            output.write(document.content)
+            output.write(document['content'])
 
     if unload:
         for document in to_remove:

--- a/holocron/ext/processors/frontmatter.py
+++ b/holocron/ext/processors/frontmatter.py
@@ -16,13 +16,13 @@ def process(app, documents, **options):
             # Match block between delimiters and block outsides of them, if
             # the block between delimiters is on the beginning of content.
             r'{0}\s*\n(.*)\n{0}\s*\n(.*)'.format(delimiter),
-            document.content, re.M | re.S)
+            document['content'], re.M | re.S)
 
         if match:
-            headers, document.content = match.groups()
+            headers, document['content'] = match.groups()
 
             for key, value in yaml.safe_load(headers).items():
-                if overwrite or not hasattr(document, key):
-                    setattr(document, key, value)
+                if overwrite or key not in document:
+                    document[key] = value
 
     return documents

--- a/holocron/ext/processors/index.py
+++ b/holocron/ext/processors/index.py
@@ -12,8 +12,8 @@ def process(app, documents, **options):
     template = app.jinja_env.get_template(template)
 
     index = content.Document(app)
-    index.content = template.render(posts=selected)
-    index.source = 'virtual://index'
-    index.destination = 'index.html'
+    index['content'] = template.render(posts=selected)
+    index['source'] = 'virtual://index'
+    index['destination'] = 'index.html'
 
     return documents + [index]

--- a/holocron/ext/processors/markdown.py
+++ b/holocron/ext/processors/markdown.py
@@ -42,20 +42,20 @@ def process(app, documents, **options):
     for document in iterdocuments(documents, when):
         # We need to strip top level heading out of the document because
         # its value is used separately in number of places.
-        match = _top_heading_re.match(document.content)
+        match = _top_heading_re.match(document['content'])
         if match:
             title = match.group('heading').strip()
-            document.content = match.group('content').strip()
+            document['content'] = match.group('content').strip()
 
             # Usually converters go after frontmatter processor and that
             # means any explicitly specified attribute is already set on
             # the document. Since frontmatter processor is considered to
             # have a higher priority, let's set 'title' iff it does't
             # exist.
-            document.title = getattr(document, 'title', title)
+            document['title'] = document.get('title', title)
 
-        document.content = markdown_.convert(document.content)
-        document.destination = \
-            '%s.html' % os.path.splitext(document.destination)[0]
+        document['content'] = markdown_.convert(document['content'])
+        document['destination'] = \
+            '%s.html' % os.path.splitext(document['destination'])[0]
 
     return documents

--- a/holocron/ext/processors/prettyuri.py
+++ b/holocron/ext/processors/prettyuri.py
@@ -9,14 +9,14 @@ def process(app, documents, **options):
     when = options.pop('when', None)
 
     for document in iterdocuments(documents, when):
-        destination = os.path.basename(document.destination)
+        destination = os.path.basename(document['destination'])
 
         # Most modern HTTP servers implicitly serve one of these files when
         # requested URL is pointing to a directory on filesystem. Hence in
         # order to provide "pretty" URLs we need to transform destination
         # address accordingly.
         if destination not in ('index.html', 'index.htm'):
-            document.destination = os.path.join(
-                os.path.splitext(document.destination)[0], 'index.html')
+            document['destination'] = os.path.join(
+                os.path.splitext(document['destination'])[0], 'index.html')
 
     return documents

--- a/holocron/ext/processors/restructuredtext.py
+++ b/holocron/ext/processors/restructuredtext.py
@@ -47,19 +47,19 @@ def process(app, documents, **options):
         writer.translator_class = _HTMLTranslator
 
         parts = publish_parts(
-            document.content, writer=writer, settings_overrides=settings)
+            document['content'], writer=writer, settings_overrides=settings)
 
-        document.content = parts['fragment'].strip()
-        document.destination = \
-            '%s.html' % os.path.splitext(document.destination)[0]
+        document['content'] = parts['fragment'].strip()
+        document['destination'] = \
+            '%s.html' % os.path.splitext(document['destination'])[0]
 
         # Usually converters go after frontmatter processor and that
         # means any explicitly specified attribute is already set on
         # the document. Since frontmatter processor is considered to
         # have a higher priority, let's set 'title' iff it does't
         # exist.
-        if not hasattr(document, 'title') and parts.get('title'):
-            document.title = parts['title']
+        if 'title' not in document and parts.get('title'):
+            document['title'] = parts['title']
 
     return documents
 

--- a/holocron/ext/processors/sitemap.py
+++ b/holocron/ext/processors/sitemap.py
@@ -29,8 +29,11 @@ def process(app, documents, **options):
 
     # Produce a virtual document with Feed.
     sitemap = content.Document(app)
-    sitemap.content = _template.render(documents=selected, encoding=encoding)
-    sitemap.source = 'virtual://sitemap'
-    sitemap.destination = 'sitemap.xml'
+    sitemap['content'] = _template.render(
+        documents=selected,
+        encoding=encoding
+    )
+    sitemap['source'] = 'virtual://sitemap'
+    sitemap['destination'] = 'sitemap.xml'
 
     return documents + [sitemap]

--- a/holocron/ext/processors/source.py
+++ b/holocron/ext/processors/source.py
@@ -78,7 +78,7 @@ def _getinstance(filename, app):
             published = ''.join(
                 _post_pattern.search(document_path).group(0).split(os.sep)[:3])
             published = datetime.datetime.strptime(published, '%Y%m%d')
-            post.published = published.date()
+            post['published'] = published.date()
 
             return post
 

--- a/holocron/ext/processors/tags.py
+++ b/holocron/ext/processors/tags.py
@@ -17,21 +17,21 @@ def process(app, documents, **options):
     tags = collections.defaultdict(list)
 
     for post in iterdocuments(documents, when):
-        if hasattr(post, 'tags'):
+        if 'tags' in post:
             tag_objects = []
-            for tag in post.tags:
+            for tag in post['tags']:
                 tags[tag].append(post)
                 tag_objects.append(_Tag(tag, output))
-            post.tags = tag_objects
+            post['tags'] = tag_objects
 
     template = app.jinja_env.get_template(template)
     inserted = []
 
     for tag in sorted(tags):
         tag_doc = content.Document(app)
-        tag_doc.content = template.render(posts=tags[tag])
-        tag_doc.source = 'virtual://tags/%s' % tag
-        tag_doc.destination = output.format(tag=tag)
+        tag_doc['content'] = template.render(posts=tags[tag])
+        tag_doc['source'] = 'virtual://tags/%s' % tag
+        tag_doc['destination'] = output.format(tag=tag)
         inserted.append(tag_doc)
 
     return documents + inserted

--- a/tests/ext/processors/test_commit.py
+++ b/tests/ext/processors/test_commit.py
@@ -83,8 +83,8 @@ def test_document_options(testapp, monkeypatch, tmpdir):
 
     assert len(documents) == 1
 
-    assert documents[0].content == '\u0421\u0438\u043b\u0430'
-    assert documents[0].destination == '1.html'
+    assert documents[0]['content'] == '\u0421\u0438\u043b\u0430'
+    assert documents[0]['destination'] == '1.html'
 
     assert tmpdir.join('_build', '1.html').read_binary() == b'\xd1\xe8\xeb\xe0'
 
@@ -165,13 +165,13 @@ def test_documents(testapp, monkeypatch, tmpdir):
 
     assert len(documents) == 2
 
-    assert documents[0].content == 'the Force #2'
-    assert documents[0].source == os.path.join('pages', '2.md')
-    assert documents[0].destination == os.path.join('pages', '2.html')
+    assert documents[0]['content'] == 'the Force #2'
+    assert documents[0]['source'] == os.path.join('pages', '2.md')
+    assert documents[0]['destination'] == os.path.join('pages', '2.html')
 
-    assert documents[1].content == 'the Force #4'
-    assert documents[1].source == os.path.join('pages', '4.md')
-    assert documents[1].destination == os.path.join('pages', '4.html')
+    assert documents[1]['content'] == 'the Force #4'
+    assert documents[1]['source'] == os.path.join('pages', '4.md')
+    assert documents[1]['destination'] == os.path.join('pages', '4.html')
 
     assert tmpdir.join('_site', 'posts', '1.html').read() == 'the Force #1'
     assert tmpdir.join('_site', 'posts', '3.html').read() == 'the Force #3'

--- a/tests/ext/processors/test_frontmatter.py
+++ b/tests/ext/processors/test_frontmatter.py
@@ -39,10 +39,10 @@ def test_document(testapp):
                 '''))
         ])
 
-    assert documents[0].author == 'Yoda'
-    assert documents[0].master
-    assert documents[0].labels == ['force', 'motto']
-    assert documents[0].content == 'May the Force be with you!\n'
+    assert documents[0]['author'] == 'Yoda'
+    assert documents[0]['master']
+    assert documents[0]['labels'] == ['force', 'motto']
+    assert documents[0]['content'] == 'May the Force be with you!\n'
 
 
 def test_document_without_frontmatter(testapp):
@@ -63,7 +63,7 @@ def test_document_without_frontmatter(testapp):
                 '''))
         ])
 
-    assert documents[0].content == textwrap.dedent('''\
+    assert documents[0]['content'] == textwrap.dedent('''\
         ---
         author: Yoda
         master: true
@@ -94,7 +94,7 @@ def text_document_with_frontmatter_in_text(testapp):
                 '''))
         ])
 
-    assert documents[0].content == textwrap.dedent('''\
+    assert documents[0]['content'] == textwrap.dedent('''\
         I am a Jedi, like my father before me.
 
         ---
@@ -126,10 +126,10 @@ def test_document_custom_delimiter(testapp):
         ],
         delimiter='+++')
 
-    assert documents[0].author == 'Yoda'
-    assert documents[0].master
-    assert documents[0].labels == ['force', 'motto']
-    assert documents[0].content == 'May the Force be with you!\n'
+    assert documents[0]['author'] == 'Yoda'
+    assert documents[0]['master']
+    assert documents[0]['labels'] == ['force', 'motto']
+    assert documents[0]['content'] == 'May the Force be with you!\n'
 
 
 def test_document_overwrite_false(testapp):
@@ -151,10 +151,10 @@ def test_document_overwrite_false(testapp):
         ],
         overwrite=False)
 
-    assert documents[0].author == 'Obi-Wan Kenobi'
-    assert documents[0].master
-    assert documents[0].labels == ['force', 'motto']
-    assert documents[0].content == 'May the Force be with you!\n'
+    assert documents[0]['author'] == 'Obi-Wan Kenobi'
+    assert documents[0]['master']
+    assert documents[0]['labels'] == ['force', 'motto']
+    assert documents[0]['content'] == 'May the Force be with you!\n'
 
 
 def test_document_invalid_yaml(testapp):
@@ -224,18 +224,18 @@ def test_documents(testapp):
             },
         ])
 
-    assert not hasattr(documents[0], 'master')
-    assert not hasattr(documents[0], 'labels')
-    assert documents[0].content == content
+    assert 'master' not in documents[0]
+    assert 'labels' not in documents[0]
+    assert documents[0]['content'] == content
 
-    assert documents[1].master
-    assert documents[1].labels == ['force', 'motto']
-    assert documents[1].content == 'May the Force be with you!\n'
+    assert documents[1]['master']
+    assert documents[1]['labels'] == ['force', 'motto']
+    assert documents[1]['content'] == 'May the Force be with you!\n'
 
-    assert not hasattr(documents[2], 'master')
-    assert not hasattr(documents[2], 'labels')
-    assert documents[2].content == content
+    assert 'master' not in documents[2]
+    assert 'labels' not in documents[2]
+    assert documents[2]['content'] == content
 
-    assert documents[3].master
-    assert documents[3].labels == ['force', 'motto']
-    assert documents[3].content == 'May the Force be with you!\n'
+    assert documents[3]['master']
+    assert documents[3]['labels'] == ['force', 'motto']
+    assert documents[3]['content'] == 'May the Force be with you!\n'

--- a/tests/ext/processors/test_markdown.py
+++ b/tests/ext/processors/test_markdown.py
@@ -40,10 +40,10 @@ def test_document(testapp):
         (
             '<p>text with <strong>bold</strong></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert documents[0].title == 'some title'
+    assert documents[0]['destination'].endswith('.html')
+    assert documents[0]['title'] == 'some title'
 
 
 def test_document_with_alt_title_syntax(testapp):
@@ -65,10 +65,10 @@ def test_document_with_alt_title_syntax(testapp):
         (
             '<p>text with <strong>bold</strong></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert documents[0].title == 'some title'
+    assert documents[0]['destination'].endswith('.html')
+    assert documents[0]['title'] == 'some title'
 
 
 def test_document_with_newlines_at_the_beginning(testapp):
@@ -91,10 +91,10 @@ def test_document_with_newlines_at_the_beginning(testapp):
         (
             '<p>text with <strong>bold</strong></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert documents[0].title == 'some title'
+    assert documents[0]['destination'].endswith('.html')
+    assert documents[0]['title'] == 'some title'
 
 
 def test_document_without_title(testapp):
@@ -113,10 +113,10 @@ def test_document_without_title(testapp):
         (
             '<p>text with <strong>bold</strong></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_title_is_not_overwritten(testapp):
@@ -128,17 +128,17 @@ def test_document_title_is_not_overwritten(testapp):
 
             text with **bold**
         '''))
-    document.title = 'another title'
+    document['title'] = 'another title'
     documents = markdown.process(testapp, [document])
 
     assert re.match(
         (
             '<p>text with <strong>bold</strong></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert documents[0].title == 'another title'
+    assert documents[0]['destination'].endswith('.html')
+    assert documents[0]['title'] == 'another title'
 
 
 def test_document_title_ignored_in_the_middle_of_text(testapp):
@@ -163,10 +163,10 @@ def test_document_title_ignored_in_the_middle_of_text(testapp):
             '<h1>some title</h1>\s*'
             '<p>text with <strong>bold</strong></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_sections(testapp):
@@ -210,10 +210,10 @@ def test_document_with_sections(testapp):
             '<h1>some title 2</h1>\s*<p>xxx</p>\s*'
             '<h2>some section 3</h2>\s*<p>yyy</p>\s*'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert documents[0].title == 'some title 1'
+    assert documents[0]['destination'].endswith('.html')
+    assert documents[0]['title'] == 'some title 1'
 
 
 def test_document_with_code(testapp):
@@ -235,10 +235,10 @@ def test_document_with_code(testapp):
         (
             '<p>test codeblock</p>\s*.*codehilite.*<pre>[\s\S]+</pre>.*'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_fenced_code(testapp):
@@ -259,10 +259,10 @@ def test_document_with_fenced_code(testapp):
         (
             '.*codehilite.*<pre>[\s\S]+</pre>.*'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_table(testapp):
@@ -279,16 +279,16 @@ def test_document_with_table(testapp):
                 '''))
         ])
 
-    assert 'table' in documents[0].content
+    assert 'table' in documents[0]['content']
 
-    assert '<th>column a</th>' in documents[0].content
-    assert '<th>column b</th>' in documents[0].content
+    assert '<th>column a</th>' in documents[0]['content']
+    assert '<th>column b</th>' in documents[0]['content']
 
-    assert '<td>foo</td>' in documents[0].content
-    assert '<td>bar</td>' in documents[0].content
+    assert '<td>foo</td>' in documents[0]['content']
+    assert '<td>bar</td>' in documents[0]['content']
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_inline_code(testapp):
@@ -303,9 +303,9 @@ def test_document_with_inline_code(testapp):
                 '''))
         ])
 
-    assert documents[0].content == '<p>test <code>code</code></p>'
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['content'] == '<p>test <code>code</code></p>'
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_custom_extensions(testapp):
@@ -328,10 +328,10 @@ def test_document_with_custom_extensions(testapp):
         (
             '<p><code>lambda x: pass</code></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_documents(testapp):
@@ -365,22 +365,22 @@ def test_documents(testapp):
             },
         ])
 
-    assert documents[0].source == '0.txt'
-    assert documents[0].content == '**wookiee**'
-    assert documents[0].destination.endswith('0.txt')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['source'] == '0.txt'
+    assert documents[0]['content'] == '**wookiee**'
+    assert documents[0]['destination'].endswith('0.txt')
+    assert 'title' not in documents[0]
 
-    assert documents[1].source == '1.md'
-    assert documents[1].content == '<p><strong>wookiee</strong></p>'
-    assert documents[1].destination.endswith('1.html')
-    assert not hasattr(documents[1], 'title')
+    assert documents[1]['source'] == '1.md'
+    assert documents[1]['content'] == '<p><strong>wookiee</strong></p>'
+    assert documents[1]['destination'].endswith('1.html')
+    assert 'title' not in documents[1]
 
-    assert documents[2].source == '2'
-    assert documents[2].content == '# wookiee'
-    assert documents[2].destination.endswith('2')
-    assert not hasattr(documents[2], 'title')
+    assert documents[2]['source'] == '2'
+    assert documents[2]['content'] == '# wookiee'
+    assert documents[2]['destination'].endswith('2')
+    assert 'title' not in documents[2]
 
-    assert documents[3].source == '3.markdown'
-    assert documents[3].content == ''
-    assert documents[3].destination.endswith('3.html')
-    assert documents[3].title == 'wookiee'
+    assert documents[3]['source'] == '3.markdown'
+    assert documents[3]['content'] == ''
+    assert documents[3]['destination'].endswith('3.html')
+    assert documents[3]['title'] == 'wookiee'

--- a/tests/ext/processors/test_prettyuri.py
+++ b/tests/ext/processors/test_prettyuri.py
@@ -29,7 +29,7 @@ def test_document(testapp):
             _get_document(destination='about/cv.html'),
         ])
 
-    assert documents[0].destination == 'about/cv/index.html'
+    assert documents[0]['destination'] == 'about/cv/index.html'
 
 
 @pytest.mark.parametrize('index', [
@@ -45,7 +45,7 @@ def test_document_index(testapp, index):
             _get_document(destination=os.path.join('about', 'cv', index)),
         ])
 
-    assert documents[0].destination == os.path.join('about', 'cv', index)
+    assert documents[0]['destination'] == os.path.join('about', 'cv', index)
 
 
 def test_documents(testapp):
@@ -67,7 +67,7 @@ def test_documents(testapp):
             },
         ])
 
-    assert documents[0].destination == '0.txt'
-    assert documents[1].destination == '1/index.html'
-    assert documents[2].destination == '2.html'
-    assert documents[3].destination == '3/index.html'
+    assert documents[0]['destination'] == '0.txt'
+    assert documents[1]['destination'] == '1/index.html'
+    assert documents[2]['destination'] == '2.html'
+    assert documents[3]['destination'] == '3/index.html'

--- a/tests/ext/processors/test_restructuredtext.py
+++ b/tests/ext/processors/test_restructuredtext.py
@@ -41,10 +41,10 @@ def test_document(testapp):
         (
             '<p>text with <strong>bold</strong></p>\s*'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert documents[0].title == 'some title'
+    assert documents[0]['destination'].endswith('.html')
+    assert documents[0]['title'] == 'some title'
 
 
 def test_document_with_subsection(testapp):
@@ -73,10 +73,10 @@ def test_document_with_subsection(testapp):
             '<h2>some section</h2>\s*'
             '<p>text with <strong>bold</strong></p>\s*'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert documents[0].title == 'some title'
+    assert documents[0]['destination'].endswith('.html')
+    assert documents[0]['title'] == 'some title'
 
 
 def test_document_without_title(testapp):
@@ -95,10 +95,10 @@ def test_document_without_title(testapp):
         (
             '<p>text with <strong>bold</strong></p>\s*'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_sections(testapp):
@@ -149,10 +149,10 @@ def test_document_with_sections(testapp):
             '<h3>some section 3</h3>\s*'
             '<p>yyy</p>\s*'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_code(testapp):
@@ -175,10 +175,10 @@ def test_document_with_code(testapp):
         (
             r'<p>test codeblock</p>\s*<pre.*python[^>]*>[\s\S]+</pre>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_inline_code(testapp):
@@ -197,10 +197,10 @@ def test_document_with_inline_code(testapp):
         (
             '<p>test <code>code</code></p>'
         ),
-        documents[0].content)
+        documents[0]['content'])
 
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_document_with_setting(testapp):
@@ -235,9 +235,9 @@ def test_document_with_setting(testapp):
             '<h3>section 2</h3>\s*'
             '<p>bbb</p>\s*'
         ),
-        documents[0].content)
-    assert documents[0].destination.endswith('.html')
-    assert not hasattr(documents[0], 'title')
+        documents[0]['content'])
+    assert documents[0]['destination'].endswith('.html')
+    assert 'title' not in documents[0]
 
 
 def test_documents(testapp):
@@ -271,22 +271,22 @@ def test_documents(testapp):
             },
         ])
 
-    assert documents[0].source == '0.txt'
-    assert documents[0].content == '**wookiee**'
-    assert documents[0].destination.endswith('0.txt')
-    assert not hasattr(documents[0], 'title')
+    assert documents[0]['source'] == '0.txt'
+    assert documents[0]['content'] == '**wookiee**'
+    assert documents[0]['destination'].endswith('0.txt')
+    assert 'title' not in documents[0]
 
-    assert documents[1].source == '1.rst'
-    assert documents[1].content == '<p><strong>wookiee</strong></p>'
-    assert documents[1].destination.endswith('1.html')
-    assert not hasattr(documents[1], 'title')
+    assert documents[1]['source'] == '1.rst'
+    assert documents[1]['content'] == '<p><strong>wookiee</strong></p>'
+    assert documents[1]['destination'].endswith('1.html')
+    assert 'title' not in documents[1]
 
-    assert documents[2].source == '2'
-    assert documents[2].content == 'wookiee\n======='
-    assert documents[2].destination.endswith('2')
-    assert not hasattr(documents[2], 'title')
+    assert documents[2]['source'] == '2'
+    assert documents[2]['content'] == 'wookiee\n======='
+    assert documents[2]['destination'].endswith('2')
+    assert 'title' not in documents[2]
 
-    assert documents[3].source == '3.rest'
-    assert documents[3].content == ''
-    assert documents[3].destination.endswith('3.html')
-    assert documents[3].title == 'wookiee'
+    assert documents[3]['source'] == '3.rest'
+    assert documents[3]['content'] == ''
+    assert documents[3]['destination'].endswith('3.html')
+    assert documents[3]['title'] == 'wookiee'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -281,30 +281,35 @@ class TestHolocronDefaults(HolocronTestCase):
             },
         ])
 
-        document = mock.Mock(
-            source='2.tst', content='text:2', destination='2.rst')
-        del document.key
+        document_a = holocron.content.Document(app)
+        document_a['source'] = '1.rst'
+        document_a['destination'] = '1.rst'
+        document_a['content'] = 'text:1'
+
+        document_b = holocron.content.Document(app)
+        document_b['source'] = '2.tst'
+        document_b['destination'] = '2.tst'
+        document_b['content'] = 'text:2'
 
         processor_options = copy.deepcopy(app.conf['processors'][-1])
         documents = app._processors[processor_options.pop('name')](
             app,
             [
-                mock.Mock(
-                    source='1.rst', content='text:1', destination='1.rst'),
-                document,
+                document_a,
+                document_b,
             ],
             **processor_options)
 
         self.assertEqual(len(documents), 2)
 
-        self.assertEqual(documents[0].source, '1.rst')
-        self.assertEqual(documents[0].destination, '1.rst')
-        self.assertEqual(documents[0].content, 'text:1')
+        self.assertEqual(documents[0]['source'], '1.rst')
+        self.assertEqual(documents[0]['destination'], '1.rst')
+        self.assertEqual(documents[0]['content'], 'text:1')
 
-        self.assertEqual(documents[1].source, '2.tst')
-        self.assertEqual(documents[1].destination, '2.html')
-        self.assertEqual(documents[1].content, 'processed:text:2')
-        self.assertEqual(documents[1].key, 'value')
+        self.assertEqual(documents[1]['source'], '2.tst')
+        self.assertEqual(documents[1]['destination'], '2.html')
+        self.assertEqual(documents[1]['content'], 'processed:text:2')
+        self.assertEqual(documents[1]['key'], 'value')
 
 
 class TestCreateApp(HolocronTestCase):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -45,7 +45,7 @@ class DocumentTestCase(HolocronTestCase):
         self.app = Holocron(self._conf)
         self.app.add_converter(FakeConverter())
         self.doc = self.document_class(self.app)
-        self.doc.destination = self.document_filename
+        self.doc['destination'] = self.document_filename
 
 
 class TestDocument(DocumentTestCase):
@@ -92,8 +92,8 @@ class TestPage(DocumentTestCase):
         The page instance has to has a set of default attributes with
         valid values.
         """
-        self.assertEqual(self.doc.author, self.app.conf['site.author'])
-        self.assertEqual(self.doc.template, self.document_class.template)
+        self.assertEqual(self.doc['author'], self.app.conf['site.author'])
+        self.assertEqual(self.doc['template'], self.document_class.template)
 
 
 class TestPost(TestPage):


### PR DESCRIPTION
Processors pipeline architecture brought schema-less documents
converting statically defined class representation with dictionaries.
Therefore, there's no sense to continue using attribute syntax to get
access to documents data especially in the light that compatibility
layer will be removed one day.