### PR TITLE
Do not use local datetime where not important

### DIFF
--- a/holocron/content.py
+++ b/holocron/content.py
@@ -39,6 +39,14 @@ class Document(dict):
         # backward compatibility. It will be removed in Holocron 0.5.0.
         self[attr] = value
 
+    def __getitem__(self, item):
+        if item in ('created_local', 'updated_local'):
+            warnings.warn(
+                "Do not use *_local datetimes as they are deprecated. "
+                "Instead use UTC based datetimes and convert to local "
+                "time explicitly where needed.")
+        return super().__getitem__(item)
+
     @property
     def url(self):
         destination = self['destination']

--- a/holocron/ext/processors/atom.py
+++ b/holocron/ext/processors/atom.py
@@ -33,7 +33,7 @@ _template = jinja2.Template(textwrap.dedent('''\
         <id>{{ doc.abs_url }}</id>
 
         <published>{{ doc.published.isoformat() }}</published>
-        <updated>{{ doc.updated_local.isoformat() }}</updated>
+        <updated>{{ doc.updated.isoformat() }}</updated>
 
         <author>
           <name>{{ doc.author }}</name>

--- a/tests/ext/processors/test_atom.py
+++ b/tests/ext/processors/test_atom.py
@@ -34,13 +34,13 @@ def test_document(testapp):
                 title='Essay',
                 content='the way of the Force',
                 destination=os.path.join('posts', '1.html'),
-                updated_local=timepoint,
+                updated=timepoint,
                 published=datetime.date(2017, 9, 25)),
         ])
 
     assert documents[0]['content'] == 'the way of the Force'
     assert documents[0]['destination'] == os.path.join('posts', '1.html')
-    assert documents[0]['updated_local'] == timepoint
+    assert documents[0]['updated'] == timepoint
     assert documents[0]['published'] == datetime.date(2017, 9, 25)
 
     assert documents[1]['source'] == 'virtual://feed'
@@ -137,7 +137,7 @@ def test_document_options(testapp):
                 title='Essay #%d' % i,
                 content='the way of the Force',
                 destination=os.path.join('posts', '%d.html' % i),
-                updated_local=timepoint,
+                updated=timepoint,
                 published=datetime.date(2017, 9, i + 1))
             for i in range(10)
         ],
@@ -149,7 +149,7 @@ def test_document_options(testapp):
     for i, document in enumerate(documents[:-1]):
         assert document['content'] == 'the way of the Force'
         assert document['destination'] == os.path.join('posts', '%d.html' % i)
-        assert document['updated_local'] == timepoint
+        assert document['updated'] == timepoint
         assert document['published'] == datetime.date(2017, 9, i + 1)
 
     # Ensure a virtual feed document contains proper values.
@@ -249,28 +249,28 @@ def test_documents(testapp):
                 content='the way of the Force',
                 source=os.path.join('posts', '1.md'),
                 destination=os.path.join('posts', '1.html'),
-                updated_local=timepoint,
+                updated=timepoint,
                 published=datetime.date(2017, 9, 1)),
             _get_document(
                 title='Essay #2',
                 content='the way of the Force',
                 source=os.path.join('pages', '2.md'),
                 destination=os.path.join('pages', '2.html'),
-                updated_local=timepoint,
+                updated=timepoint,
                 published=datetime.date(2017, 9, 2)),
             _get_document(
                 title='Essay #3',
                 content='the way of the Force',
                 source=os.path.join('posts', '3.md'),
                 destination=os.path.join('posts', '3.html'),
-                updated_local=timepoint,
+                updated=timepoint,
                 published=datetime.date(2017, 9, 3)),
             _get_document(
                 title='Essay #4',
                 content='the way of the Force',
                 source=os.path.join('pages', '4.md'),
                 destination=os.path.join('pages', '4.html'),
-                updated_local=timepoint,
+                updated=timepoint,
                 published=datetime.date(2017, 9, 4)),
         ],
         when=[


### PR DESCRIPTION
Every experienced developer knows: do not mess with datetimes, it's
trickier that it looks. One of the best practices here is to store
everything in UTC, doing conversion to local time (or any other tz)
on system edges.

Let's follow this advise in Holocron, and use UTC where we don't care
much about representation. One of such things here is Atom processor.
As for _local datetimes, let's depreacte them and remove in the future.