### PR TITLE
Add pipeline processor

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -523,6 +523,13 @@ class Holocron(object):
         env.globals.update(**self._theme_ctx)
         return env
 
+    def invoke_processors(self, documents, pipeline):
+        for processor in pipeline:
+            processor = processor.copy()
+            processfn = self._processors[processor.pop('name')]
+            documents = processfn(self, documents, **processor)
+        return documents
+
     def run(self):
         """
         Starts build process.
@@ -540,9 +547,7 @@ class Holocron(object):
                 'pattern': r'^static/',
             }])
 
-        for idx, processor in enumerate(self.conf['processors']):
-            processfn = self._processors[processor.pop('name')]
-            documents = processfn(self, documents, **processor)
+        documents = self.invoke_processors(documents, self.conf['processors'])
 
         # use generators to generate additional stuff
         for generator in self._generators:

--- a/holocron/ext/processors/_misc.py
+++ b/holocron/ext/processors/_misc.py
@@ -18,9 +18,17 @@ def evalcondition(condition, document):
 
 
 def iterdocuments(documents, when):
-    for document in documents:
-        if when is not None:
-            if all((evalcondition(cond, document) for cond in when)):
-                yield document
-        else:
+    for document, is_matched in iterdocuments_ex(documents, when):
+        if is_matched:
             yield document
+
+
+def iterdocuments_ex(documents, when):
+    for document in documents:
+        is_matched = True
+
+        if when is not None:
+            if any((not evalcondition(cond, document) for cond in when)):
+                is_matched = False
+
+        yield document, is_matched

--- a/holocron/ext/processors/pipeline.py
+++ b/holocron/ext/processors/pipeline.py
@@ -1,0 +1,20 @@
+"""Run separate processors pipeline on selected documents."""
+
+
+from ._misc import iterdocuments_ex
+
+
+def process(app, documents, **options):
+    processors = options.pop('processors', [])
+    when = options.pop('when', None)
+
+    kept = []
+    selected = []
+
+    for document, is_matched in iterdocuments_ex(documents, when):
+        if is_matched:
+            selected.append(document)
+        else:
+            kept.append(document)
+
+    return kept + app.invoke_processors(selected, processors)

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'holocron.ext.processors': [
             'source = holocron.ext.processors.source:process',
             'metadata = holocron.ext.processors.metadata:process',
+            'pipeline = holocron.ext.processors.pipeline:process',
             'frontmatter = holocron.ext.processors.frontmatter:process',
             'prettyuri = holocron.ext.processors.prettyuri:process',
             'markdown = holocron.ext.processors.markdown:process',

--- a/tests/ext/processors/test_pipeline.py
+++ b/tests/ext/processors/test_pipeline.py
@@ -1,0 +1,151 @@
+"""Pipeline processor test suite."""
+
+
+import os
+
+import pytest
+
+from holocron import app, content
+from holocron.ext.processors import pipeline
+
+
+def _get_document(cls=content.Document, **kwargs):
+    document = cls(app.Holocron({}))
+    document.update(kwargs)
+    return document
+
+
+@pytest.fixture(scope='function')
+def testapp():
+    def spam(app, documents, **options):
+        for document in documents:
+            document['spam'] = options.get('text', 42)
+        return documents
+
+    def eggs(app, documents, **options):
+        for document in documents:
+            document['content'] += ' #friedeggs'
+        return documents
+
+    def rice(app, documents, **options):
+        document = content.Document(app)
+        document['content'] = 'rice'
+        documents.append(document)
+        return documents
+
+    instance = app.Holocron({})
+    instance.add_processor('spam', spam)
+    instance.add_processor('eggs', eggs)
+    instance.add_processor('rice', rice)
+
+    return instance
+
+
+def test_document(testapp):
+    """Pipeline processor has to work!"""
+
+    documents = pipeline.process(
+        testapp,
+        [
+            _get_document(content='the Force', author='skywalker'),
+        ],
+        processors=[
+            {'name': 'spam'},
+            {'name': 'eggs'},
+            {'name': 'rice'},
+        ])
+
+    assert len(documents) == 2
+
+    assert documents[0]['content'] == 'the Force #friedeggs'
+    assert documents[0]['author'] == 'skywalker'
+    assert documents[0]['spam'] == 42
+
+    assert documents[1]['content'] == 'rice'
+
+
+def test_document_processor_with_option(testapp):
+    """Pipeline processor has to pass down processors options."""
+
+    documents = pipeline.process(
+        testapp,
+        [
+            _get_document(content='the Force', author='skywalker'),
+        ],
+        processors=[
+            {'name': 'spam', 'text': 1},
+        ])
+
+    assert len(documents) == 1
+
+    assert documents[0]['content'] == 'the Force'
+    assert documents[0]['author'] == 'skywalker'
+    assert documents[0]['spam'] == 1
+
+
+def test_document_no_processors(testapp):
+    """Pipeline processor with no processors has to passed by."""
+
+    documents = pipeline.process(
+        testapp,
+        [
+            _get_document(content='the Force', author='skywalker'),
+        ])
+
+    assert len(documents) == 1
+
+    assert documents[0]['content'] == 'the Force'
+    assert documents[0]['author'] == 'skywalker'
+
+
+def test_documents(testapp):
+    """Metadata processor has to ignore non-targeted documents."""
+
+    documents = pipeline.process(
+        testapp,
+        [
+            _get_document(
+                content='the way of the Force #1',
+                source=os.path.join('posts', '1.md')),
+            _get_document(
+                content='the way of the Force #2',
+                source=os.path.join('pages', '2.md')),
+            _get_document(
+                content='the way of the Force #3',
+                source=os.path.join('posts', '3.md')),
+            _get_document(
+                content='the way of the Force #4',
+                source=os.path.join('pages', '4.md')),
+        ],
+        processors=[
+            {'name': 'spam'},
+            {'name': 'eggs'},
+            {'name': 'rice'},
+        ],
+        when=[
+            {
+                'operator': 'match',
+                'attribute': 'source',
+                'pattern': r'^posts.*$',
+            },
+        ])
+
+    assert len(documents) == 5
+
+    assert documents[0]['content'] == 'the way of the Force #2'
+    assert documents[0]['source'] == os.path.join('pages', '2.md')
+    assert 'spam' not in documents[0]
+
+    assert documents[1]['content'] == 'the way of the Force #4'
+    assert documents[1]['source'] == os.path.join('pages', '4.md')
+    assert 'spam' not in documents[1]
+
+    assert documents[2]['content'] == 'the way of the Force #1 #friedeggs'
+    assert documents[2]['source'] == os.path.join('posts', '1.md')
+    assert documents[2]['spam'] == 42
+
+    assert documents[3]['content'] == 'the way of the Force #3 #friedeggs'
+    assert documents[3]['source'] == os.path.join('posts', '3.md')
+    assert documents[3]['spam'] == 42
+
+    assert documents[4]['content'] == 'rice'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -156,6 +156,7 @@ class TestHolocronDefaults(HolocronTestCase):
         self.assertEqual(set(app._processors), set([
             'source',
             'metadata',
+            'pipeline',
             'frontmatter',
             'markdown',
             'restructuredtext',
@@ -354,6 +355,7 @@ class TestCreateApp(HolocronTestCase):
         self.assertEqual(set(app._processors), set([
             'source',
             'metadata',
+            'pipeline',
             'frontmatter',
             'markdown',
             'restructuredtext',


### PR DESCRIPTION
Pipeline processor is a good way to follow DRY and to collect all
processors that need to be applied for a certain (the same) set of
documents under one umbrella.

For instance, we want to:

 * set a custom template for all blog posts;
 * generate an Atom feed with all blog posts;
 * generate an index page with all blog posts;

In order to achieve this we need to specify 'when' condition for each
processor independently, which complicates readability and increase
maintenance cost since user need to keep all these conditions in-sync.

Pipeline processor, on the other hand, allows to specify 'when'
condition only once, and run processors pipeline for only matched set of
documents.