### PR TITLE
Do not set default 'author' on documents

### DIFF
--- a/holocron/content.py
+++ b/holocron/content.py
@@ -85,10 +85,7 @@ class Page(Document):
       ===================  ========================  ==============
 
     """
-
-    def __init__(self, *args, **kwargs):
-        super(Page, self).__init__(*args, **kwargs)
-        self['author'] = self._app.conf['site.author']
+    pass
 
 
 class Post(Page):

--- a/tests/ext/processors/test_atom.py
+++ b/tests/ext/processors/test_atom.py
@@ -13,6 +13,7 @@ from holocron.ext.processors import atom
 
 def _get_document(cls=content.Page, **kwargs):
     document = cls(app.Holocron({}))
+    document['author'] = 'Obi-Wan Kenobi'
     document.update(kwargs)
     return document
 

--- a/tests/ext/processors/test_frontmatter.py
+++ b/tests/ext/processors/test_frontmatter.py
@@ -139,6 +139,7 @@ def test_document_overwrite_false(testapp):
         testapp,
         [
             _get_document(
+                author='Obi-Wan Kenobi',
                 content=textwrap.dedent('''\
                     ---
                     author: Yoda

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -424,6 +424,26 @@ class TestCreateApp(HolocronTestCase):
                 ],
             },
             {
+                'name': 'metadata',
+                'metadata':
+                    {'template': 'page.j2',
+                     'author': 'Obi-Wan Kenobi'},
+                'when': [
+                    {'attribute': 'source',
+                     'operator': 'match',
+                     'pattern': r'.*\.(markdown|md|mdown|mkd|rest|rst)$'}],
+            },
+            {
+                'name': 'metadata',
+                'metadata':
+                    {'template': 'post.j2'},
+                'when': [
+                    {'attribute': 'source',
+                     'operator': 'match',
+                     'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
+                                '\\.(markdown|md|mdown|mkd|rest|rst)$'}],
+            },
+            {
                 'name': 'atom',
                 'when': [
                     {'attribute': 'source',
@@ -456,25 +476,6 @@ class TestCreateApp(HolocronTestCase):
                      'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
                                 '\\.(markdown|md|mdown|mkd|rest|rst)$'}],
                 'output': 'tags/{tag}/index.html',
-            },
-            {
-                'name': 'metadata',
-                'metadata':
-                    {'template': 'page.j2'},
-                'when': [
-                    {'attribute': 'source',
-                     'operator': 'match',
-                     'pattern': r'.*\.(markdown|md|mdown|mkd|rest|rst)$'}],
-            },
-            {
-                'name': 'metadata',
-                'metadata':
-                    {'template': 'post.j2'},
-                'when': [
-                    {'attribute': 'source',
-                     'operator': 'match',
-                     'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
-                                '\\.(markdown|md|mdown|mkd|rest|rst)$'}],
             },
             {
                 'name': 'commit',
@@ -531,6 +532,26 @@ class TestCreateApp(HolocronTestCase):
                 ],
             },
             {
+                'name': 'metadata',
+                'metadata':
+                    {'template': 'page.j2',
+                     'author': 'Obi-Wan Kenobi'},
+                'when': [
+                    {'attribute': 'source',
+                     'operator': 'match',
+                     'pattern': r'.*\.(markdown|md|mdown|mkd)$'}],
+            },
+            {
+                'name': 'metadata',
+                'metadata':
+                    {'template': 'post.j2'},
+                'when': [
+                    {'attribute': 'source',
+                     'operator': 'match',
+                     'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
+                                '\\.(markdown|md|mdown|mkd)$'}],
+            },
+            {
                 'name': 'atom',
                 'when': [
                     {'attribute': 'source',
@@ -556,25 +577,6 @@ class TestCreateApp(HolocronTestCase):
                                 '\\.(markdown|md|mdown|mkd)$'}],
             },
             {
-                'name': 'metadata',
-                'metadata':
-                    {'template': 'page.j2'},
-                'when': [
-                    {'attribute': 'source',
-                     'operator': 'match',
-                     'pattern': r'.*\.(markdown|md|mdown|mkd)$'}],
-            },
-            {
-                'name': 'metadata',
-                'metadata':
-                    {'template': 'post.j2'},
-                'when': [
-                    {'attribute': 'source',
-                     'operator': 'match',
-                     'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
-                                '\\.(markdown|md|mdown|mkd)$'}],
-            },
-            {
                 'name': 'commit',
                 'path': '_build',
                 'encoding': 'utf-8',
@@ -587,6 +589,9 @@ class TestCreateApp(HolocronTestCase):
         processors settings.
         """
         app = self._create_app(conf_raw=textwrap.dedent('''\
+            site:
+              author: V
+
             encoding:
               output: my-out-enc
 
@@ -669,6 +674,26 @@ class TestCreateApp(HolocronTestCase):
                 ],
             },
             {
+                'name': 'metadata',
+                'metadata':
+                    {'template': 'page.j2',
+                     'author': 'V'},
+                'when': [
+                    {'attribute': 'source',
+                     'operator': 'match',
+                     'pattern': r'.*\.(markdown|md|mdown|mkd|rest|rst)$'}],
+            },
+            {
+                'name': 'metadata',
+                'metadata':
+                    {'template': 'post.j2'},
+                'when': [
+                    {'attribute': 'source',
+                     'operator': 'match',
+                     'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
+                                '\\.(markdown|md|mdown|mkd|rest|rst)$'}],
+            },
+            {
                 'name': 'atom',
                 'when': [
                     {'attribute': 'source',
@@ -701,25 +726,6 @@ class TestCreateApp(HolocronTestCase):
                      'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
                                 '\\.(markdown|md|mdown|mkd|rest|rst)$'}],
                 'output': 'tags-{tag}.html',
-            },
-            {
-                'name': 'metadata',
-                'metadata':
-                    {'template': 'page.j2'},
-                'when': [
-                    {'attribute': 'source',
-                     'operator': 'match',
-                     'pattern': r'.*\.(markdown|md|mdown|mkd|rest|rst)$'}],
-            },
-            {
-                'name': 'metadata',
-                'metadata':
-                    {'template': 'post.j2'},
-                'when': [
-                    {'attribute': 'source',
-                     'operator': 'match',
-                     'pattern': '\\d{2,4}/\\d{1,2}/\\d{1,2}.*'
-                                '\\.(markdown|md|mdown|mkd|rest|rst)$'}],
             },
             {
                 'name': 'commit',
@@ -758,7 +764,8 @@ class TestCreateApp(HolocronTestCase):
             {
                 'name': 'metadata',
                 'metadata':
-                    {'template': 'page.j2'},
+                    {'template': 'page.j2',
+                     'author': 'Obi-Wan Kenobi'},
                 'when': [
                     {'attribute': 'source',
                      'operator': 'match',

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -87,13 +87,6 @@ class TestPage(DocumentTestCase):
         """
         super(TestPage, self).setUp()
 
-    def test_default_attributes(self):
-        """
-        The page instance has to has a set of default attributes with
-        valid values.
-        """
-        self.assertEqual(self.doc['author'], self.app.conf['site.author'])
-
 
 class TestPost(TestPage):
     """


### PR DESCRIPTION
Holocron used to have default 'author' that was assigned as document's
attribute if nothing was provided in YAML frontmatter. Moving towards
processor pipeline architecture, we end up with general framework that
could be used to create any static site, not only blog. Hence, it's
better to do not make any assumptions and defaults, unless something
is stated explicitly by user.

In this case, setting such attributes as 'author' needs to be done by
user using metadata processor.