### PR TITLE
Drop Python3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'watchdog >= 0.8.0',    # deps of serve command
     ],
     tests_require=['mock >= 1.1.0'],
-    python_requires='>=3.3',
+    python_requires='>=3.4',
 
     entry_points={
         'console_scripts': [
@@ -89,7 +89,6 @@ setup(
 
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py35, py36, docs
+envlist = py34, py35, py36, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Pytest dropped support for Python3.3, which results in failing Travis
builds for `py3.3` env. Since Python3.3 is reaching its end of life,
it is decided to drop support for it in Holocron.