### PR TITLE
Add support for named pipelines

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -100,7 +100,7 @@ class Holocron(object):
 
         'theme': {},
 
-        'processors': [],
+        'pipelines': {},
 
         'commands': {
             'serve': {
@@ -239,7 +239,7 @@ class Holocron(object):
 
     def run(self):
         """
-        Starts build process.
+        (DEPRECATED) Starts build process.
         """
         documents = []
 
@@ -254,6 +254,7 @@ class Holocron(object):
                 'pattern': r'^static/',
             }])
 
-        documents = self.invoke_processors(documents, self.conf['processors'])
+        processors = self.conf['pipelines.build']
+        documents = self.invoke_processors(documents, processors)
 
         print('Documents were built successfully')

--- a/holocron/ext/commands/run.py
+++ b/holocron/ext/commands/run.py
@@ -1,0 +1,16 @@
+"""Run named pipeline."""
+
+from holocron.ext import abc
+
+
+class Run(abc.Command):
+    """A command that runs named pipeline."""
+
+    def set_arguments(self, parser):
+        parser.add_argument('pipeline', help='a pipeline to run')
+
+    def execute(self, app, arguments):
+        if arguments.pipeline not in app.conf['pipelines']:
+            raise ValueError('%s: no such pipeline' % arguments.pipeline)
+
+        app.invoke_processors([], app.conf['pipelines'][arguments.pipeline])

--- a/holocron/main.py
+++ b/holocron/main.py
@@ -1,13 +1,4 @@
-"""
-    holocron.main
-    ~~~~~~~~~~~~~
-
-    This module provides a command line interface and an entry point for
-    end users.
-
-    :copyright: (c) 2014 by the Holocron Team, see AUTHORS for details.
-    :license: 3-clause BSD, see LICENSE for details.
-"""
+"""Yo! Holocron CLI is here!"""
 
 import sys
 import logging

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
             'init = holocron.ext.commands.init:Init',
             'build = holocron.ext.commands.build:Build',
             'serve = holocron.ext.commands.serve:Serve',
+            'run = holocron.ext.commands.run:Run',
         ],
     },
 

--- a/tests/ext/commands/test_run.py
+++ b/tests/ext/commands/test_run.py
@@ -1,0 +1,46 @@
+"""Run command test suite."""
+
+import argparse
+
+import pytest
+
+from holocron.app import Holocron
+from holocron.ext.commands import run
+
+
+@pytest.fixture
+def testapp():
+    app = Holocron({
+        'pipelines': {
+            'alpha': [{'name': 'set_marker', 'marker': 13}],
+            'omega': [{'name': 'set_marker', 'marker': 42}],
+        }
+    })
+
+    def set_marker(app, documents, marker):
+        setattr(app, 'marker', marker)
+    app.add_processor('set_marker', set_marker)
+
+    return app
+
+
+@pytest.fixture
+def testcommand():
+    return run.Run()
+
+
+def test_run_missed(testapp, testcommand):
+    with pytest.raises(ValueError, match='missed: no such pipeline'):
+        testcommand.execute(testapp, argparse.Namespace(pipeline='missed'))
+
+
+def test_run_alpha(testapp, testcommand):
+    testcommand.execute(testapp, argparse.Namespace(pipeline='alpha'))
+
+    assert getattr(testapp, 'marker') == 13
+
+
+def test_run_omega(testapp, testcommand):
+    testcommand.execute(testapp, argparse.Namespace(pipeline='omega'))
+
+    assert getattr(testapp, 'marker') == 42


### PR DESCRIPTION
Named pipelines is a way to maintain more than one pipeline for the
site. There could be various use cases. For instance, a user may want
to have two building pipelines: one for production, and one for
development. Another example may be is that from now on, there's no need
to maintain commands as any command may be a pipeline.