### PR TITLE
Set desired timezone for created/updated datetimes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'PyYAML   >= 3.11',     # core
         'dooku    >= 0.3.0',    # core
         'Pygments >= 2.0',      # core since required for various converters
+        'python-dateutil >= 2.7',
 
         'Markdown >= 2.4',      # deps of markdown converter
         'docutils >= 0.12',     # deps of restructuredtext converter


### PR DESCRIPTION
Both created and updated datetimes may be shown on site pages, thus it's
required we show them using expected timezone. Since we do not want to
do timezone conversions in Jinja templates, we better use desired
timezone from the very beginning and cast to UTC whenever required.