### PR TITLE
Resolve JSON references in app.invoke_processors()

### DIFF
--- a/holocron/app.py
+++ b/holocron/app.py
@@ -19,7 +19,7 @@ from dooku.conf import Conf
 from dooku.decorator import cached_property
 from dooku.ext import ExtensionManager
 
-from .ext.processors import source
+from .ext.processors import source, _misc
 
 
 logger = logging.getLogger(__name__)
@@ -225,6 +225,14 @@ class Holocron(object):
         for processor in pipeline:
             processor = processor.copy()
             processfn = self._processors[processor.pop('name')]
+
+            # Resolve every JSON reference we encounter in a processor's
+            # parameters. Please note, we're doing this so late because we
+            # want to take into account metadata and other changes produced
+            # by previous processors in the pipeline.
+            processor = _misc.resolve_json_references(
+                processor, {':metadata:': self.metadata})
+
             documents = processfn(self, documents, **processor)
         return documents
 

--- a/holocron/ext/processors/_misc.py
+++ b/holocron/ext/processors/_misc.py
@@ -78,9 +78,6 @@ class parameters:
             documents = arguments.pop('documents')
 
             for name, value in arguments.items():
-                value = resolve_json_references(
-                    value, {':application:': app.conf})
-
                 # this is a temporary hack to workaround schema error
                 # that dooku.conf.Conf is not a dict
                 if isinstance(value, dooku.conf.Conf):

--- a/tests/ext/processors/test_commit.py
+++ b/tests/ext/processors/test_commit.py
@@ -179,29 +179,6 @@ def test_documents(testapp, monkeypatch, tmpdir):
     assert tmpdir.join('_site', 'posts', '3.html').read() == 'the Force #3'
 
 
-def test_parameters_jsonref(testapp, tmpdir):
-    testapp.conf.update({
-        'extra': {'path': tmpdir.strpath},
-        'unload': False,
-        'encoding': 'CP1251',
-    })
-
-    documents = commit.process(
-        testapp,
-        [
-            {
-                'content': 'оби-ван',
-                'destination': 'test.txt',
-            },
-        ],
-        path={'$ref': ':application:#/extra/path'},
-        unload={'$ref': ':application:#/unload'},
-        encoding={'$ref': ':application:#/encoding'})
-
-    assert len(documents) == 1
-    assert tmpdir.join('test.txt').read_text('CP1251') == 'оби-ван'
-
-
 @pytest.mark.parametrize('options, error', [
     ({'path': 42}, "path: 42 should be instance of 'str'"),
     ({'when': [42]}, 'when: unsupported value'),
@@ -211,19 +188,3 @@ def test_parameters_jsonref(testapp, tmpdir):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         commit.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('path', 42, "path: 42 should be instance of 'str'"),
-    ('when', [42], 'when: unsupported value'),
-    ('encoding', 'UTF-42', 'encoding: unsupported encoding'),
-    ('unload', 42, "unload: 42 should be instance of 'bool'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        commit.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_feed.py
+++ b/tests/ext/processors/test_feed.py
@@ -669,20 +669,3 @@ def test_documents(testapp, syndication_format):
 def test_parameter_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         feed.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', [42], 'when: unsupported value'),
-    ('encoding', 'UTF-42', 'encoding: unsupported encoding'),
-    ('limit', '42', "limit: must be null or positive integer"),
-    ('save_as', 42, "save_as: 42 should be instance of 'str'"),
-    ('pretty', 42, "pretty: 42 should be instance of 'bool'"),
-])
-def test_parameter_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        feed.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_frontmatter.py
+++ b/tests/ext/processors/test_frontmatter.py
@@ -241,36 +241,6 @@ def test_documents(testapp):
     assert documents[3]['content'] == 'May the Force be with you!\n'
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({
-        'extra': {'delimiter': '>-<'},
-        'ow': False,
-    })
-
-    content = textwrap.dedent('''\
-        >-<
-        master: true
-        labels: [force, motto]
-        >-<
-
-        May the Force be with you!
-    ''')
-
-    documents = frontmatter.process(
-        testapp,
-        [
-            _get_document(content=content, master=False),
-        ],
-        delimiter={'$ref': ':application:#/extra/delimiter'},
-        overwrite={'$ref': ':application:#/ow'})
-
-    assert len(documents) == 1
-
-    assert not documents[0]['master']
-    assert documents[0]['labels'] == ['force', 'motto']
-    assert documents[0]['content'] == 'May the Force be with you!\n'
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'delimiter': 42}, "delimiter: 42 should be instance of 'str'"),
@@ -279,18 +249,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         frontmatter.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', [42], 'when: unsupported value'),
-    ('delimiter', 42, "delimiter: 42 should be instance of 'str'"),
-    ('overwrite', 'true', "overwrite: 'true' should be instance of 'bool'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        frontmatter.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_index.py
+++ b/tests/ext/processors/test_index.py
@@ -163,34 +163,6 @@ def test_documents(testapp):
     assert entries[2].a.attrs['href'] == '/posts/1.html'
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({
-        'extra': {'template': 'index.j2'},
-        'enc': 'CP1251',
-    })
-
-    documents = index.process(
-        testapp,
-        [
-            _get_document(
-                title='история оби-вана',
-                destination=os.path.join('posts', '1.html'),
-                published=datetime.date(2017, 10, 4)),
-        ],
-        template={'$ref': ':application:#/extra/template'},
-        encoding={'$ref': ':application:#/enc'})
-
-    assert len(documents) == 2
-
-    assert documents[0]['title'] == 'история оби-вана'
-    assert documents[0]['destination'] == os.path.join('posts', '1.html')
-    assert documents[0]['published'] == datetime.date(2017, 10, 4)
-
-    assert documents[-1]['source'] == 'virtual://index'
-    assert documents[-1]['destination'] == 'index.html'
-    assert documents[-1]['encoding'] == 'CP1251'
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': 42}, 'when: unsupported value'),
     ({'template': 42}, "template: 42 should be instance of 'str'"),
@@ -199,18 +171,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         index.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', 42, 'when: unsupported value'),
-    ('template', 42, "template: 42 should be instance of 'str'"),
-    ('encoding', 'UTF-42', 'encoding: unsupported encoding'),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        index.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_markdown.py
+++ b/tests/ext/processors/test_markdown.py
@@ -385,32 +385,6 @@ def test_documents(testapp):
     assert documents[3]['title'] == 'wookiee'
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({'extra': {'ext': []}})
-
-    documents = markdown.process(
-        testapp,
-        [
-            _get_document(
-                content=textwrap.dedent('''\
-                    ```
-                    lambda x: pass
-                    ```
-                '''))
-        ],
-        extensions={'$ref': ':application:#/extra/ext'})
-
-    # when no extensions are passed, syntax highlighting is turned off
-    assert re.match(
-        (
-            r'<p><code>lambda x: pass</code></p>'
-        ),
-        documents[0]['content'])
-
-    assert documents[0]['destination'].endswith('.html')
-    assert 'title' not in documents[0]
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'extensions': 42}, "extensions: 42 should be instance of 'list'"),
@@ -418,17 +392,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         markdown.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', [42], 'when: unsupported value'),
-    ('extensions', 42, "extensions: 42 should be instance of 'list'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        markdown.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_metadata.py
+++ b/tests/ext/processors/test_metadata.py
@@ -128,26 +128,6 @@ def test_documents(testapp):
     assert 'author' not in documents[3]
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({
-        'extra': {'master': 'luke', 'yoda': 'dead'},
-        'ow': False,
-    })
-
-    documents = metadata.process(
-        testapp,
-        [
-            _get_document(yoda='alive'),
-        ],
-        metadata={'$ref': ':application:#/extra'},
-        overwrite={'$ref': ':application:#/ow'})
-
-    assert len(documents) == 1
-
-    assert documents[0]['master'] == 'luke'
-    assert documents[0]['yoda'] == 'alive'
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'metadata': 42}, "metadata: 42 should be instance of 'dict'"),
@@ -156,18 +136,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         metadata.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', [42], 'when: unsupported value'),
-    ('metadata', 42, "metadata: 42 should be instance of 'dict'"),
-    ('overwrite', 'true', "overwrite: 'true' should be instance of 'bool'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        metadata.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_pipeline.py
+++ b/tests/ext/processors/test_pipeline.py
@@ -151,18 +151,6 @@ def test_documents(testapp):
     assert documents[4]['content'] == 'rice'
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({'extra': {'procs': [{'name': 'rice'}]}})
-
-    documents = pipeline.process(
-        testapp,
-        [],
-        processors={'$ref': ':application:#/extra/procs'})
-
-    assert len(documents) == 1
-    assert documents[0]['content'] == 'rice'
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'processors': 42}, "processors: 42 should be instance of 'list'"),
@@ -170,17 +158,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         pipeline.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', [42], 'when: unsupported value'),
-    ('processors', 42, "processors: 42 should be instance of 'list'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        pipeline.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_prettyuri.py
+++ b/tests/ext/processors/test_prettyuri.py
@@ -78,16 +78,3 @@ def test_documents(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         prettyuri.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', [42], 'when: unsupported value'),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        prettyuri.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_restructuredtext.py
+++ b/tests/ext/processors/test_restructuredtext.py
@@ -291,41 +291,6 @@ def test_documents(testapp):
     assert documents[3]['title'] == 'wookiee'
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({'extra': {'initial_header_level': 3}})
-
-    documents = restructuredtext.process(
-        testapp,
-        [
-            _get_document(
-                content=textwrap.dedent('''\
-                    section 1
-                    =========
-
-                    aaa
-
-                    section 2
-                    =========
-
-                    bbb
-                '''))
-        ],
-        docutils={'$ref': ':application:#/extra'})
-
-    # by default, initial header level is 2 and so the sections would
-    # start with <h2>
-    assert re.match(
-        (
-            r'<h3>section 1</h3>\s*'
-            r'<p>aaa</p>\s*'
-            r'<h3>section 2</h3>\s*'
-            r'<p>bbb</p>\s*'
-        ),
-        documents[0]['content'])
-    assert documents[0]['destination'].endswith('.html')
-    assert 'title' not in documents[0]
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'docutils': 42}, "docutils: 42 should be instance of 'dict'"),
@@ -333,17 +298,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         restructuredtext.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', [42], 'when: unsupported value'),
-    ('docutils', 42, "docutils: 42 should be instance of 'dict'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        restructuredtext.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_sitemap.py
+++ b/tests/ext/processors/test_sitemap.py
@@ -179,22 +179,6 @@ def test_documents(testapp):
     }
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({
-        'extra': {'compression': True},
-        'save_sitemap_as': 'foo.xml',
-    })
-
-    documents = sitemap.process(
-        testapp,
-        [],
-        gzip={'$ref': ':application:#/extra/compression'},
-        save_as={'$ref': ':application:#/save_sitemap_as'})
-
-    assert len(documents) == 1
-    assert documents[0]['destination'] == 'foo.xml.gz'
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': 42}, 'when: unsupported value'),
     ({'gzip': 'true'}, "gzip: 'true' should be instance of 'bool'"),
@@ -203,18 +187,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         sitemap.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', 42, 'when: unsupported value'),
-    ('gzip', 'true', "gzip: 'true' should be instance of 'bool'"),
-    ('save_as', 42, "save_as: 42 should be instance of 'str'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        sitemap.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/ext/processors/test_tags.py
+++ b/tests/ext/processors/test_tags.py
@@ -256,24 +256,6 @@ def test_documents(testapp):
     assert entries[2].a.attrs['href'] == '/posts/1.html'
 
 
-def test_parameters_jsonref(testapp):
-    testapp.conf.update({'extra': {'outpattern': 'mytags/{tag}/index.html'}})
-
-    documents = tags.process(
-        testapp,
-        [
-            _get_document(
-                title='the way of the Force',
-                destination=os.path.join('posts', '1.html'),
-                published=datetime.date(2017, 10, 4),
-                tags=['kenobi', 'skywalker']),
-        ],
-        output={'$ref': ':application:#/extra/outpattern'})
-
-    assert documents[-2]['source'] == 'virtual://tags/kenobi'
-    assert documents[-2]['destination'] == 'mytags/kenobi/index.html'
-
-
 @pytest.mark.parametrize('options, error', [
     ({'when': 42}, 'when: unsupported value'),
     ({'template': 42}, "template: 42 should be instance of 'str'"),
@@ -282,18 +264,3 @@ def test_parameters_jsonref(testapp):
 def test_parameters_schema(testapp, options, error):
     with pytest.raises(ValueError, match=error):
         tags.process(testapp, [], **options)
-
-
-@pytest.mark.parametrize('option_name, option_value, error', [
-    ('when', 42, 'when: unsupported value'),
-    ('template', 42, "template: 42 should be instance of 'str'"),
-    ('output', 42, "output: 42 should be instance of 'str'"),
-])
-def test_parameters_jsonref_schema(testapp, option_name, option_value, error):
-    testapp.conf.update({'test': {option_name: option_value}})
-
-    with pytest.raises(ValueError, match=error):
-        tags.process(
-            testapp,
-            [],
-            **{option_name: {'$ref': ':application:#/test/%s' % option_name}})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -318,6 +318,27 @@ def test_invoke_processors_propagates_options(testapp, processor_options):
     testapp.invoke_processors([], [dict(processor_options, name='processor')])
 
 
+@pytest.mark.parametrize('options, resolved', [
+    ({'a': {'$ref': ':metadata:#/is_yoda_master'}}, {'a': True}),
+    ({'a': {'$ref': ':metadata:#/extra/0/luke'}}, {'a': 'skywalker'}),
+    ({'a': {'$ref': ':metadata:#/is_yoda_master'},
+      'b': {'$ref': ':metadata:#/extra/0/luke'}},
+     {'a': True, 'b': 'skywalker'}),
+    ({'a': {'$ref': ':document:#/content'}},
+     {'a': {'$ref': ':document:#/content'}}),
+])
+def test_invoke_processors_resolves_jsonref(testapp, options, resolved):
+    testapp.metadata.update({
+        'extra': [{'luke': 'skywalker'}],
+        'is_yoda_master': True,
+    })
+
+    def processor(app, documents, **options):
+        assert options == resolved
+    testapp.add_processor('processor', processor)
+    testapp.invoke_processors([], [dict(options, name='processor')])
+
+
 @pytest.mark.parametrize('initial_documents', [
     [{'a': 1}],
     [{'a': 1, 'b': 1.13}],


### PR DESCRIPTION
In order to reduce complexity and remove a burden of being responsible
to resolve JSON references in processors from their authors, it does
make sense to move that code out from @parameters decorator (that's
completely optional) to invoke_processors() function.