### PR TITLE
Make processors' parameters are kwargs only

### DIFF
--- a/holocron/ext/processors/commit.py
+++ b/holocron/ext/processors/commit.py
@@ -18,6 +18,7 @@ from ._misc import iterdocuments, parameters
 )
 def process(app,
             documents,
+            *,
             path='_site',
             when=None,
             unload=True,

--- a/holocron/ext/processors/feed.py
+++ b/holocron/ext/processors/feed.py
@@ -23,6 +23,7 @@ from holocron.content import Document
 )
 def process(app,
             documents,
+            *,
             feed,
             item,
             syndication_format='atom',

--- a/holocron/ext/processors/frontmatter.py
+++ b/holocron/ext/processors/frontmatter.py
@@ -15,7 +15,7 @@ from ._misc import iterdocuments, parameters
         'overwrite': schema.Schema(bool),
     }
 )
-def process(app, documents, when=None, delimiter='---', overwrite=True):
+def process(app, documents, *, when=None, delimiter='---', overwrite=True):
     delimiter = re.escape(delimiter)
 
     for document in iterdocuments(documents, when):

--- a/holocron/ext/processors/index.py
+++ b/holocron/ext/processors/index.py
@@ -14,7 +14,12 @@ from holocron.content import Document
         'encoding': schema.Schema(codecs.lookup, 'unsupported encoding'),
     }
 )
-def process(app, documents, when=None, template='index.j2', encoding='UTF-8'):
+def process(app,
+            documents,
+            *,
+            when=None,
+            template='index.j2',
+            encoding='UTF-8'):
     selected = iterdocuments(documents, when)
     template = app.jinja_env.get_template(template)
 

--- a/holocron/ext/processors/markdown.py
+++ b/holocron/ext/processors/markdown.py
@@ -35,7 +35,7 @@ _top_heading_re = re.compile(
         'extensions': schema.Schema([str]),
     }
 )
-def process(app, documents, when=None, extensions=None):
+def process(app, documents, *, when=None, extensions=None):
     markdown_ = markdown.Markdown(
         # No one use pure Markdown nowadays, so let's enhance it with some
         # popular and widely used extensions such as tables, footnotes and

--- a/holocron/ext/processors/metadata.py
+++ b/holocron/ext/processors/metadata.py
@@ -12,7 +12,7 @@ from ._misc import iterdocuments, parameters
         'overwrite': schema.Schema(bool),
     }
 )
-def process(app, documents, when=None, metadata={}, overwrite=True):
+def process(app, documents, *, when=None, metadata={}, overwrite=True):
     for document in iterdocuments(documents, when):
         for key, value in metadata.items():
             if overwrite or key not in document:

--- a/holocron/ext/processors/pipeline.py
+++ b/holocron/ext/processors/pipeline.py
@@ -11,7 +11,7 @@ from ._misc import iterdocuments_ex, parameters
         'processors': schema.Schema([{str: object}]),
     }
 )
-def process(app, documents, when=None, processors=[]):
+def process(app, documents, *, when=None, processors=[]):
     kept = []
     selected = []
 

--- a/holocron/ext/processors/prettyuri.py
+++ b/holocron/ext/processors/prettyuri.py
@@ -11,7 +11,7 @@ from ._misc import iterdocuments, parameters
         'when': schema.Or([{str: object}], None, error='unsupported value'),
     }
 )
-def process(app, documents, when=None):
+def process(app, documents, *, when=None):
     for document in iterdocuments(documents, when):
         destination = os.path.basename(document['destination'])
 

--- a/holocron/ext/processors/restructuredtext.py
+++ b/holocron/ext/processors/restructuredtext.py
@@ -16,7 +16,7 @@ from ._misc import iterdocuments, parameters
         'docutils': schema.Schema({str: object}),
     }
 )
-def process(app, documents, when=None, docutils={}):
+def process(app, documents, *, when=None, docutils={}):
     settings = dict(
         {
             # We need to start heading level with <h2> in case there are

--- a/holocron/ext/processors/sitemap.py
+++ b/holocron/ext/processors/sitemap.py
@@ -43,7 +43,7 @@ def _check_documents_urls(sitemap, documents):
         'save_as': schema.Schema(str),
     }
 )
-def process(app, documents, when=None, gzip=False, save_as='sitemap.xml'):
+def process(app, documents, *, when=None, gzip=False, save_as='sitemap.xml'):
     # According to the Sitemap protocol, the output encoding must be UTF-8.
     # Since this processor does not perform any I/O, the only thing we can
     # do here is to provide bytes representing UTF-8 encoded XML.

--- a/holocron/ext/processors/source.py
+++ b/holocron/ext/processors/source.py
@@ -22,6 +22,7 @@ from ._misc import iterdocuments, parameters
 )
 def process(app,
             documents,
+            *,
             path='.',
             when=None,
             encoding='UTF-8',

--- a/holocron/ext/processors/tags.py
+++ b/holocron/ext/processors/tags.py
@@ -16,6 +16,7 @@ from holocron import content
 )
 def process(app,
             documents,
+            *,
             when=None,
             template='index.j2',
             output='tags/{tag}.html'):


### PR DESCRIPTION
Initially there were a design decision that processors receive their
parameters as keyword arguments only. Unfortunately, we lost this
contract and decision in our implementations by replacing **options with
certain parameters and respective defaults in function signature. Let's
put it back then!