### PR TITLE
Improve tests quality

### DIFF
--- a/tests/ext/processors/test_commit.py
+++ b/tests/ext/processors/test_commit.py
@@ -35,7 +35,7 @@ def test_document(testapp, monkeypatch, tmpdir):
                 destination=os.path.join('posts', '1.html')),
         ])
 
-    assert documents == []
+    assert len(documents) == 0
 
     text = tmpdir.join('_site', 'posts', '1.html').read()
     assert text == 'the Force'
@@ -57,7 +57,7 @@ def test_document_template(testapp, monkeypatch, tmpdir):
         ],
         encoding='CP1251')
 
-    assert documents == []
+    assert len(documents) == 0
 
     html = tmpdir.join('_site', 'posts', '1.html').read()
     soup = bs4.BeautifulSoup(html, 'html.parser')
@@ -67,31 +67,61 @@ def test_document_template(testapp, monkeypatch, tmpdir):
     assert list(soup.article.stripped_strings)[1] == 'the Force'
 
 
-def test_document_options(testapp, monkeypatch, tmpdir):
-    """Commit processor has to respect custom options."""
+@pytest.mark.parametrize('encoding', ['CP1251', 'UTF-16'])
+def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
+    """Commit processor has to respect encoding."""
 
     monkeypatch.chdir(tmpdir)
 
     documents = commit.process(
         testapp,
         [
-            _get_document(
-                content='\u0421\u0438\u043b\u0430',
-                destination='1.html'),
+            _get_document(content='оби-ван', destination='1.html'),
         ],
-        path='_build',
-        unload=False,
-        encoding='CP1251')
+        encoding=encoding)
 
-    assert len(documents) == 1
-
-    assert documents[0]['content'] == '\u0421\u0438\u043b\u0430'
-    assert documents[0]['destination'] == '1.html'
-
-    assert tmpdir.join('_build', '1.html').read_binary() == b'\xd1\xe8\xeb\xe0'
+    assert len(documents) == 0
+    assert tmpdir.join('_site', '1.html').read_text(encoding) == 'оби-ван'
 
 
-def test_document_with_custom_encoding(testapp, monkeypatch, tmpdir):
+@pytest.mark.parametrize('unload', [False, True])
+def test_param_unload(testapp, monkeypatch, tmpdir, unload):
+    """Commit processor has to respect unload parameter."""
+
+    monkeypatch.chdir(tmpdir)
+
+    documents = commit.process(
+        testapp,
+        [
+            _get_document(content='obi-wan', destination='1.html'),
+        ],
+        unload=unload)
+
+    assert len(documents) == int(not unload)
+
+    if not unload:
+        assert documents[0]['content'] == 'obi-wan'
+        assert documents[0]['destination'] == '1.html'
+
+
+@pytest.mark.parametrize('path', ['_build', '_public'])
+def test_param_path(testapp, monkeypatch, tmpdir, path):
+    """Commit processor has to respect path parameter."""
+
+    monkeypatch.chdir(tmpdir)
+
+    documents = commit.process(
+        testapp,
+        [
+            _get_document(content='obi-wan', destination='1.html'),
+        ],
+        path=path)
+
+    assert len(documents) == 0
+    assert tmpdir.join(path, '1.html').read() == 'obi-wan'
+
+
+def test_document_custom_encoding(testapp, monkeypatch, tmpdir):
     """Commit processor has to respect suggested encoding."""
 
     monkeypatch.chdir(tmpdir)
@@ -100,15 +130,18 @@ def test_document_with_custom_encoding(testapp, monkeypatch, tmpdir):
         testapp,
         [
             _get_document(
-                content='\u0421\u0438\u043b\u0430',
+                content='оби-ван',
                 encoding='CP1251',
                 destination='1.html'),
+            _get_document(
+                content='оби-ван',
+                destination='2.html'),
         ],
         encoding='UTF-8')
 
     assert len(documents) == 0
-
-    assert tmpdir.join('_site', '1.html').read_binary() == b'\xd1\xe8\xeb\xe0'
+    assert tmpdir.join('_site', '1.html').read_text('CP1251') == 'оби-ван'
+    assert tmpdir.join('_site', '2.html').read_text('UTF-8') == 'оби-ван'
 
 
 @pytest.mark.parametrize('data, loader', [
@@ -128,11 +161,11 @@ def test_document_content_types(testapp, monkeypatch, tmpdir, data, loader):
                 destination=os.path.join('cv.pdf')),
         ])
 
-    assert documents == []
+    assert len(documents) == 0
     assert loader(tmpdir.join('_site', 'cv.pdf')) == data
 
 
-def test_documents(testapp, monkeypatch, tmpdir):
+def test_param_when(testapp, monkeypatch, tmpdir):
     """Commit processor has to ignore non-relevant documents."""
 
     monkeypatch.chdir(tmpdir)
@@ -179,12 +212,14 @@ def test_documents(testapp, monkeypatch, tmpdir):
     assert tmpdir.join('_site', 'posts', '3.html').read() == 'the Force #3'
 
 
-@pytest.mark.parametrize('options, error', [
+@pytest.mark.parametrize('params, error', [
     ({'path': 42}, "path: 42 should be instance of 'str'"),
     ({'when': [42]}, 'when: unsupported value'),
     ({'encoding': 'UTF-42'}, 'encoding: unsupported encoding'),
     ({'unload': 42}, "unload: 42 should be instance of 'bool'"),
 ])
-def test_parameters_schema(testapp, options, error):
+def test_param_bad_value(testapp, params, error):
+    """Commit processor has to validate input parameters."""
+
     with pytest.raises(ValueError, match=error):
-        commit.process(testapp, [], **options)
+        commit.process(testapp, [], **params)

--- a/tests/ext/processors/test_feed.py
+++ b/tests/ext/processors/test_feed.py
@@ -426,8 +426,8 @@ def test_document_rss_feed_metadata(testapp):
 
 @pytest.mark.parametrize('syndication_format', ['atom', 'rss'])
 @pytest.mark.parametrize('encoding', ['CP1251', 'UTF-16'])
-def test_parameter_encoding(testapp, syndication_format, encoding):
-    """Feed processor has to respect encoding option."""
+def test_param_encoding(testapp, syndication_format, encoding):
+    """Feed processor has to respect encoding parameter."""
 
     documents = feed.process(
         testapp,
@@ -463,8 +463,8 @@ def test_parameter_encoding(testapp, syndication_format, encoding):
 
 @pytest.mark.parametrize('syndication_format', ['atom', 'rss'])
 @pytest.mark.parametrize('save_as', ['foo.xml', 'bar.xml'])
-def test_parameter_save_as(testapp, syndication_format, save_as):
-    """Feed processor has to respect save_as option."""
+def test_param_save_as(testapp, syndication_format, save_as):
+    """Feed processor has to respect save_as parameter."""
 
     documents = feed.process(
         testapp,
@@ -498,8 +498,8 @@ def test_parameter_save_as(testapp, syndication_format, save_as):
 
 @pytest.mark.parametrize('syndication_format', ['atom', 'rss'])
 @pytest.mark.parametrize('limit', (2, 5))
-def test_parameter_limit(testapp, syndication_format, limit):
-    """Feed processor has to respect limit option."""
+def test_param_limit(testapp, syndication_format, limit):
+    """Feed processor has to respect limit parameter."""
 
     documents = feed.process(
         testapp,
@@ -556,8 +556,8 @@ def test_parameter_limit(testapp, syndication_format, limit):
     (False, lambda x: x == 2),
     (True, lambda x: x > 10),
 ))
-def test_parameter_pretty(testapp, syndication_format, pretty, check_fn):
-    """Feed processor has to respect pretty option."""
+def test_param_pretty(testapp, syndication_format, pretty, check_fn):
+    """Feed processor has to respect pretty parameter."""
 
     documents = feed.process(
         testapp,
@@ -590,7 +590,7 @@ def test_parameter_pretty(testapp, syndication_format, pretty, check_fn):
 
 
 @pytest.mark.parametrize('syndication_format', ['atom', 'rss'])
-def test_documents(testapp, syndication_format):
+def test_param_when(testapp, syndication_format):
     """Feed processor has to ignore non-relevant documents."""
 
     documents = feed.process(
@@ -659,13 +659,15 @@ def test_documents(testapp, syndication_format):
         assert parsed.rss.channel.item[1].title == 'Essay #1'
 
 
-@pytest.mark.parametrize('options, error', [
+@pytest.mark.parametrize('params, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'encoding': 'UTF-42'}, 'encoding: unsupported encoding'),
     ({'limit': '42'}, "limit: must be null or positive integer"),
     ({'save_as': 42}, "save_as: 42 should be instance of 'str'"),
     ({'pretty': 42}, "pretty: 42 should be instance of 'bool'"),
 ])
-def test_parameter_schema(testapp, options, error):
+def test_param_bad_value(testapp, params, error):
+    """Feed processor has to validate input parameters."""
+
     with pytest.raises(ValueError, match=error):
-        feed.process(testapp, [], **options)
+        feed.process(testapp, [], **params)

--- a/tests/ext/processors/test_markdown.py
+++ b/tests/ext/processors/test_markdown.py
@@ -35,12 +35,12 @@ def test_document(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text with <strong>bold</strong></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert documents[0]['title'] == 'some title'
 
@@ -60,12 +60,12 @@ def test_document_with_alt_title_syntax(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text with <strong>bold</strong></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert documents[0]['title'] == 'some title'
 
@@ -86,12 +86,12 @@ def test_document_with_newlines_at_the_beginning(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text with <strong>bold</strong></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert documents[0]['title'] == 'some title'
 
@@ -108,12 +108,12 @@ def test_document_without_title(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text with <strong>bold</strong></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -130,12 +130,12 @@ def test_document_title_is_not_overwritten(testapp):
     document['title'] = 'another title'
     documents = markdown.process(testapp, [document])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text with <strong>bold</strong></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert documents[0]['title'] == 'another title'
 
@@ -156,6 +156,7 @@ def test_document_title_ignored_in_the_middle_of_text(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text</p>\s*'
@@ -163,7 +164,6 @@ def test_document_title_ignored_in_the_middle_of_text(testapp):
             r'<p>text with <strong>bold</strong></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -201,6 +201,7 @@ def test_document_with_sections(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>aaa</p>\s*'
@@ -210,7 +211,6 @@ def test_document_with_sections(testapp):
             r'<h2>some section 3</h2>\s*<p>yyy</p>\s*'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert documents[0]['title'] == 'some title 1'
 
@@ -230,12 +230,12 @@ def test_document_with_code(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>test codeblock</p>\s*.*codehilite.*<pre>[\s\S]+</pre>.*'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -254,12 +254,12 @@ def test_document_with_fenced_code(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'.*codehilite.*<pre>[\s\S]+</pre>.*'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -278,14 +278,12 @@ def test_document_with_table(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert 'table' in documents[0]['content']
-
     assert '<th>column a</th>' in documents[0]['content']
     assert '<th>column b</th>' in documents[0]['content']
-
     assert '<td>foo</td>' in documents[0]['content']
     assert '<td>bar</td>' in documents[0]['content']
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -302,13 +300,14 @@ def test_document_with_inline_code(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert documents[0]['content'] == '<p>test <code>code</code></p>'
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
 
-def test_document_with_custom_extensions(testapp):
-    """Markdown processor has to respect custom extensions."""
+def test_param_extensions(testapp):
+    """Markdown processor has to respect extensions parameter."""
 
     documents = markdown.process(
         testapp,
@@ -322,18 +321,18 @@ def test_document_with_custom_extensions(testapp):
         ],
         extensions=[])
 
-    # when no extensions are passed, syntax highlighting is turned off
+    assert len(documents) == 1
     assert re.match(
         (
+            # when no extensions are passed, syntax highlighting is turned off
             r'<p><code>lambda x: pass</code></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
 
-def test_documents(testapp):
+def test_param_when(testapp):
     """Markdown processor has to ignore non-markdown documents."""
 
     documents = markdown.process(
@@ -364,6 +363,8 @@ def test_documents(testapp):
             },
         ])
 
+    assert len(documents) == 4
+
     assert documents[0]['source'] == '0.txt'
     assert documents[0]['content'] == '**wookiee**'
     assert documents[0]['destination'].endswith('0.txt')
@@ -385,10 +386,12 @@ def test_documents(testapp):
     assert documents[3]['title'] == 'wookiee'
 
 
-@pytest.mark.parametrize('options, error', [
+@pytest.mark.parametrize('params, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'extensions': 42}, "extensions: 42 should be instance of 'list'"),
 ])
-def test_parameters_schema(testapp, options, error):
+def test_param_bad_value(testapp, params, error):
+    """Markdown processor has to validate input parameters."""
+
     with pytest.raises(ValueError, match=error):
-        markdown.process(testapp, [], **options)
+        markdown.process(testapp, [], **params)

--- a/tests/ext/processors/test_metadata.py
+++ b/tests/ext/processors/test_metadata.py
@@ -33,7 +33,6 @@ def test_document(testapp):
         })
 
     assert len(documents) == 1
-
     assert documents[0]['content'] == 'the Force'
     assert documents[0]['author'] == 'yoda'
     assert documents[0]['type'] == 'memoire'
@@ -49,7 +48,6 @@ def test_document_untouched(testapp):
         ])
 
     assert len(documents) == 1
-
     assert documents[0]['content'] == 'the Force'
     assert documents[0]['author'] == 'skywalker'
 
@@ -58,7 +56,7 @@ def test_document_untouched(testapp):
     (True, 'yoda'),
     (False, 'skywalker'),
 ])
-def test_document_overwrite(testapp, overwrite, author):
+def test_param_overwrite(testapp, overwrite, author):
     """Metadata processor has to respect overwrite option."""
 
     documents = metadata.process(
@@ -73,13 +71,12 @@ def test_document_overwrite(testapp, overwrite, author):
         overwrite=overwrite)
 
     assert len(documents) == 1
-
     assert documents[0]['content'] == 'the Force'
     assert documents[0]['author'] == author
     assert documents[0]['type'] == 'memoire'
 
 
-def test_documents(testapp):
+def test_param_when(testapp):
     """Metadata processor has to ignore non-targeted documents."""
 
     documents = metadata.process(
@@ -128,11 +125,13 @@ def test_documents(testapp):
     assert 'author' not in documents[3]
 
 
-@pytest.mark.parametrize('options, error', [
+@pytest.mark.parametrize('params, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'metadata': 42}, "metadata: 42 should be instance of 'dict'"),
     ({'overwrite': 'true'}, "overwrite: 'true' should be instance of 'bool'"),
 ])
-def test_parameters_schema(testapp, options, error):
+def test_param_bad_value(testapp, params, error):
+    """Metadata processor has to validate input parameters."""
+
     with pytest.raises(ValueError, match=error):
-        metadata.process(testapp, [], **options)
+        metadata.process(testapp, [], **params)

--- a/tests/ext/processors/test_pipeline.py
+++ b/tests/ext/processors/test_pipeline.py
@@ -77,7 +77,6 @@ def test_document_processor_with_option(testapp):
         ])
 
     assert len(documents) == 1
-
     assert documents[0]['content'] == 'the Force'
     assert documents[0]['author'] == 'skywalker'
     assert documents[0]['spam'] == 1
@@ -93,13 +92,12 @@ def test_document_no_processors(testapp):
         ])
 
     assert len(documents) == 1
-
     assert documents[0]['content'] == 'the Force'
     assert documents[0]['author'] == 'skywalker'
 
 
-def test_documents(testapp):
-    """Metadata processor has to ignore non-targeted documents."""
+def test_param_when(testapp):
+    """Pipeline processor has to ignore non-targeted documents."""
 
     documents = pipeline.process(
         testapp,
@@ -151,10 +149,12 @@ def test_documents(testapp):
     assert documents[4]['content'] == 'rice'
 
 
-@pytest.mark.parametrize('options, error', [
+@pytest.mark.parametrize('params, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'processors': 42}, "processors: 42 should be instance of 'list'"),
 ])
-def test_parameters_schema(testapp, options, error):
+def test_param_bad_value(testapp, params, error):
+    """Pipeline processor has to validate input parameters."""
+
     with pytest.raises(ValueError, match=error):
-        pipeline.process(testapp, [], **options)
+        pipeline.process(testapp, [], **params)

--- a/tests/ext/processors/test_prettyuri.py
+++ b/tests/ext/processors/test_prettyuri.py
@@ -20,7 +20,7 @@ def testapp():
 
 
 def test_document(testapp):
-    """Destination has to be changed to produce a pretty URI."""
+    """Prettyuri processor has to work!"""
 
     documents = prettyuri.process(
         testapp,
@@ -28,6 +28,7 @@ def test_document(testapp):
             _get_document(destination='about/cv.html'),
         ])
 
+    assert len(documents) == 1
     assert documents[0]['destination'] == 'about/cv/index.html'
 
 
@@ -44,10 +45,11 @@ def test_document_index(testapp, index):
             _get_document(destination=os.path.join('about', 'cv', index)),
         ])
 
+    assert len(documents) == 1
     assert documents[0]['destination'] == os.path.join('about', 'cv', index)
 
 
-def test_documents(testapp):
+def test_param_when(testapp):
     """Prettyuri processor has to ignore non-targeted documents."""
 
     documents = prettyuri.process(
@@ -66,15 +68,18 @@ def test_documents(testapp):
             },
         ])
 
+    assert len(documents) == 4
     assert documents[0]['destination'] == '0.txt'
     assert documents[1]['destination'] == '1/index.html'
     assert documents[2]['destination'] == '2.html'
     assert documents[3]['destination'] == '3/index.html'
 
 
-@pytest.mark.parametrize('options, error', [
+@pytest.mark.parametrize('params, error', [
     ({'when': [42]}, 'when: unsupported value'),
 ])
-def test_parameters_schema(testapp, options, error):
+def test_param_bad_value(testapp, params, error):
+    """Prettyuri processor has to validate input parameters."""
+
     with pytest.raises(ValueError, match=error):
-        prettyuri.process(testapp, [], **options)
+        prettyuri.process(testapp, [], **params)

--- a/tests/ext/processors/test_restructuredtext.py
+++ b/tests/ext/processors/test_restructuredtext.py
@@ -36,12 +36,12 @@ def test_document(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text with <strong>bold</strong></p>\s*'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert documents[0]['title'] == 'some title'
 
@@ -66,6 +66,7 @@ def test_document_with_subsection(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>abstract</p>\s*'
@@ -73,7 +74,6 @@ def test_document_with_subsection(testapp):
             r'<p>text with <strong>bold</strong></p>\s*'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert documents[0]['title'] == 'some title'
 
@@ -90,12 +90,12 @@ def test_document_without_title(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>text with <strong>bold</strong></p>\s*'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -135,6 +135,7 @@ def test_document_with_sections(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<h2>some title 1</h2>\s*'
@@ -149,7 +150,6 @@ def test_document_with_sections(testapp):
             r'<p>yyy</p>\s*'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -170,12 +170,12 @@ def test_document_with_code(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>test codeblock</p>\s*<pre.*python[^>]*>[\s\S]+</pre>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
@@ -192,17 +192,17 @@ def test_document_with_inline_code(testapp):
                 '''))
         ])
 
+    assert len(documents) == 1
     assert re.match(
         (
             r'<p>test <code>code</code></p>'
         ),
         documents[0]['content'])
-
     assert documents[0]['destination'].endswith('.html')
     assert 'title' not in documents[0]
 
 
-def test_document_with_setting(testapp):
+def test_param_docutils(testapp):
     """reStructuredText processor has to respect custom settings."""
 
     documents = restructuredtext.process(
@@ -225,10 +225,11 @@ def test_document_with_setting(testapp):
             'initial_header_level': 3,
         })
 
-    # by default, initial header level is 2 and so the sections would
-    # start with <h2>
+    assert len(documents) == 1
     assert re.match(
         (
+            # by default, initial header level is 2 and so the sections would
+            # start with <h2>
             r'<h3>section 1</h3>\s*'
             r'<p>aaa</p>\s*'
             r'<h3>section 2</h3>\s*'
@@ -239,7 +240,7 @@ def test_document_with_setting(testapp):
     assert 'title' not in documents[0]
 
 
-def test_documents(testapp):
+def test_param_when(testapp):
     """reStructuredText processor has to ignore non-targeted documents."""
 
     documents = restructuredtext.process(
@@ -270,6 +271,8 @@ def test_documents(testapp):
             },
         ])
 
+    assert len(documents) == 4
+
     assert documents[0]['source'] == '0.txt'
     assert documents[0]['content'] == '**wookiee**'
     assert documents[0]['destination'].endswith('0.txt')
@@ -291,10 +294,12 @@ def test_documents(testapp):
     assert documents[3]['title'] == 'wookiee'
 
 
-@pytest.mark.parametrize('options, error', [
+@pytest.mark.parametrize('params, error', [
     ({'when': [42]}, 'when: unsupported value'),
     ({'docutils': 42}, "docutils: 42 should be instance of 'dict'"),
 ])
-def test_parameters_schema(testapp, options, error):
+def test_param_bad_value(testapp, params, error):
+    """reStructuredText processor has to validate input parameters."""
+
     with pytest.raises(ValueError, match=error):
-        restructuredtext.process(testapp, [], **options)
+        restructuredtext.process(testapp, [], **params)


### PR DESCRIPTION
 * Rename tests to reflect what they are.
 * Split all-in-one tests into multiple.
 * Ensure every test has a docstring.