### PR TITLE
Add fallback= option to @parameters decorator

### DIFF
--- a/holocron/ext/processors/commit.py
+++ b/holocron/ext/processors/commit.py
@@ -9,6 +9,9 @@ from ._misc import iterdocuments, parameters
 
 
 @parameters(
+    fallback={
+        'encoding': ':metadata:#/encoding',
+    },
     schema={
         'path': str,
         'when': schema.Or([{str: object}], None, error='unsupported value'),

--- a/holocron/ext/processors/feed.py
+++ b/holocron/ext/processors/feed.py
@@ -11,6 +11,9 @@ from holocron.content import Document
 
 
 @parameters(
+    fallback={
+        'encoding': ':metadata:#/encoding',
+    },
     schema={
         'when': schema.Or([{str: object}], None, error='unsupported value'),
         'save_as': schema.Schema(str),

--- a/holocron/ext/processors/index.py
+++ b/holocron/ext/processors/index.py
@@ -8,6 +8,9 @@ from holocron.content import Document
 
 
 @parameters(
+    fallback={
+        'encoding': ':metadata:#/encoding',
+    },
     schema={
         'when': schema.Or([{str: object}], None, error='unsupported value'),
         'template': schema.Schema(str),

--- a/holocron/ext/processors/source.py
+++ b/holocron/ext/processors/source.py
@@ -13,6 +13,10 @@ from ._misc import iterdocuments, parameters
 
 
 @parameters(
+    fallback={
+        'encoding': ':metadata:#/encoding',
+        'timezone': ':metadata:#/timezone',
+    },
     schema={
         'path': str,
         'when': schema.Or([{str: object}], None, error='unsupported value'),

--- a/holocron/ext/processors/tags.py
+++ b/holocron/ext/processors/tags.py
@@ -1,5 +1,6 @@
 """Generate tags page."""
 
+import codecs
 import collections
 import schema
 
@@ -8,9 +9,13 @@ from holocron import content
 
 
 @parameters(
+    fallback={
+        'encoding': ':metadata:#/encoding',
+    },
     schema={
         'when': schema.Or([{str: object}], None, error='unsupported value'),
         'template': schema.Schema(str),
+        'encoding': schema.Schema(codecs.lookup, 'unsupported encoding'),
         'output': schema.Schema(str),
     }
 )
@@ -19,6 +24,7 @@ def process(app,
             *,
             when=None,
             template='index.j2',
+            encoding='UTF-8',
             output='tags/{tag}.html'):
     app.metadata['show_tags'] = True
 
@@ -38,9 +44,10 @@ def process(app,
 
     for tag in sorted(tags):
         tag_doc = content.Document(app)
-        tag_doc['content'] = template.render(posts=tags[tag])
+        tag_doc['content'] = template.render(posts=tags[tag]).encode(encoding)
         tag_doc['source'] = 'virtual://tags/%s' % tag
         tag_doc['destination'] = output.format(tag=tag)
+        tag_doc['encoding'] = encoding
         inserted.append(tag_doc)
 
     return documents + inserted

--- a/tests/ext/processors/test_commit.py
+++ b/tests/ext/processors/test_commit.py
@@ -69,7 +69,7 @@ def test_document_template(testapp, monkeypatch, tmpdir):
 
 @pytest.mark.parametrize('encoding', ['CP1251', 'UTF-16'])
 def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
-    """Commit processor has to respect encoding."""
+    """Commit processor has to respect encoding parameter."""
 
     monkeypatch.chdir(tmpdir)
 
@@ -79,6 +79,23 @@ def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
             _get_document(content='оби-ван', destination='1.html'),
         ],
         encoding=encoding)
+
+    assert len(documents) == 0
+    assert tmpdir.join('_site', '1.html').read_text(encoding) == 'оби-ван'
+
+
+@pytest.mark.parametrize('encoding', ['CP1251', 'UTF-16'])
+def test_param_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
+    """Commit processor has to respect encoding parameter (fallback)."""
+
+    monkeypatch.chdir(tmpdir)
+    testapp.metadata.update({'encoding': encoding})
+
+    documents = commit.process(
+        testapp,
+        [
+            _get_document(content='оби-ван', destination='1.html'),
+        ])
 
     assert len(documents) == 0
     assert tmpdir.join('_site', '1.html').read_text(encoding) == 'оби-ван'

--- a/tests/ext/processors/test_index.py
+++ b/tests/ext/processors/test_index.py
@@ -134,6 +134,34 @@ def test_param_encoding(testapp, encoding):
     assert documents[-1]['content'].decode(encoding)
 
 
+@pytest.mark.parametrize('encoding', ['CP1251', 'UTF-16'])
+def test_param_encoding_fallback(testapp, encoding):
+    """Index processor has to to respect encoding parameter (fallback)."""
+
+    testapp.metadata.update({'encoding': encoding})
+
+    documents = index.process(
+        testapp,
+        [
+            _get_document(
+                title='оби-ван',
+                destination=os.path.join('posts', '1.html'),
+                published=datetime.date(2017, 10, 4)),
+        ])
+
+    assert len(documents) == 2
+
+    assert documents[0]['title'] == 'оби-ван'
+    assert documents[0]['destination'] == os.path.join('posts', '1.html')
+    assert documents[0]['published'] == datetime.date(2017, 10, 4)
+
+    assert documents[-1]['source'] == 'virtual://index'
+    assert documents[-1]['destination'] == 'index.html'
+    assert documents[-1]['encoding'] == encoding
+
+    assert documents[-1]['content'].decode(encoding)
+
+
 def test_param_when(testapp):
     """Index processor has to ignore non-relevant documents."""
 

--- a/tests/ext/processors/test_tags.py
+++ b/tests/ext/processors/test_tags.py
@@ -197,6 +197,71 @@ def test_param_output(testapp):
     assert entries[1].a.attrs['href'] == '/posts/1.html'
 
 
+@pytest.mark.parametrize('encoding', ['CP1251', 'UTF-16'])
+def test_param_encoding(testapp, encoding):
+    """Tags processor has to respect encoding parameter."""
+
+    documents = tags.process(
+        testapp,
+        [
+            _get_document(
+                title='the way of the Force',
+                destination=os.path.join('posts', '1.html'),
+                published=datetime.date(2017, 10, 4),
+                tags=['kenobi', 'skywalker']),
+        ],
+        encoding=encoding)
+
+    assert len(documents) == 3
+
+    assert documents[0]['title'] == 'the way of the Force'
+    assert documents[0]['destination'] == os.path.join('posts', '1.html')
+    assert documents[0]['published'] == datetime.date(2017, 10, 4)
+
+    assert documents[1]['source'] == 'virtual://tags/kenobi'
+    assert documents[1]['destination'] == 'tags/kenobi.html'
+    assert documents[1]['encoding'] == encoding
+    assert documents[1]['content'].decode(encoding)
+
+    assert documents[2]['source'] == 'virtual://tags/skywalker'
+    assert documents[2]['destination'] == 'tags/skywalker.html'
+    assert documents[2]['encoding'] == encoding
+    assert documents[2]['content'].decode(encoding)
+
+
+@pytest.mark.parametrize('encoding', ['CP1251', 'UTF-16'])
+def test_param_encoding_fallback(testapp, encoding):
+    """Tags processor has to respect encoding parameter (fallback)."""
+
+    testapp.metadata.update({'encoding': encoding})
+
+    documents = tags.process(
+        testapp,
+        [
+            _get_document(
+                title='the way of the Force',
+                destination=os.path.join('posts', '1.html'),
+                published=datetime.date(2017, 10, 4),
+                tags=['kenobi', 'skywalker']),
+        ])
+
+    assert len(documents) == 3
+
+    assert documents[0]['title'] == 'the way of the Force'
+    assert documents[0]['destination'] == os.path.join('posts', '1.html')
+    assert documents[0]['published'] == datetime.date(2017, 10, 4)
+
+    assert documents[1]['source'] == 'virtual://tags/kenobi'
+    assert documents[1]['destination'] == 'tags/kenobi.html'
+    assert documents[1]['encoding'] == encoding
+    assert documents[1]['content'].decode(encoding)
+
+    assert documents[2]['source'] == 'virtual://tags/skywalker'
+    assert documents[2]['destination'] == 'tags/skywalker.html'
+    assert documents[2]['encoding'] == encoding
+    assert documents[2]['content'].decode(encoding)
+
+
 def test_param_when(testapp):
     """Tags processor has to ignore non-relevant documents."""
 


### PR DESCRIPTION
This option is my attempt to achieve a good UX in Holocron by providing
consistent and DRY settings as well as being flexible enough to
overwrite each value on per-processor basis. Essentially, fallback= is a
way to say "hey, please try to extract a value from the metadata if it's
passed" and Holocron will do the rest. This is a safe attempt. If
nothing found under the specified key, a processor will use its default
value instead.