### PR TITLE
Rename index processor to archive processor

### DIFF
--- a/holocron/ext/processors/archive.py
+++ b/holocron/ext/processors/archive.py
@@ -1,4 +1,4 @@
-"""Generate index page."""
+"""Generate an archive page."""
 
 import itertools
 
@@ -13,14 +13,14 @@ from ._misc import parameters
         'save_as': schema.Schema(str),
     }
 )
-def process(app, stream, *, template='index.j2', save_as='index.html'):
+def process(app, stream, *, template='archive.j2', save_as='index.html'):
     passthrough, stream = itertools.tee(stream)
 
     index = {
-        'source': 'index://%s' % save_as,
+        'source': 'archive://%s' % save_as,
         'destination': save_as,
         'template': template,
-        'documents': list(stream),
+        'items': list(stream),
     }
 
     yield from passthrough

--- a/holocron/theme/templates/archive.j2
+++ b/holocron/theme/templates/archive.j2
@@ -7,7 +7,7 @@
 
 {#- Prints all posts grouped by year. -#}
 <div class="index">
-{% for group in posts|groupby('published.year')|sort(attribute='grouper', reverse=True) %}
+{% for group in items|groupby('published.year')|sort(attribute='grouper', reverse=True) %}
   <span class="year">{{ group.grouper }}</span>
 
   {% for post in group.list|sort(attribute='published', reverse=True) %}

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
             '   holocron.ext.processors.restructuredtext:process',
             'feed = holocron.ext.processors.feed:process',
             'sitemap = holocron.ext.processors.sitemap:process',
-            'index = holocron.ext.processors.index:process',
+            'archive = holocron.ext.processors.archive:process',
             'commit = holocron.ext.processors.commit:process',
             'jinja2 = holocron.ext.processors.jinja2:process',
         ],

--- a/tests/ext/processors/test_archive.py
+++ b/tests/ext/processors/test_archive.py
@@ -1,11 +1,11 @@
-"""Index processor test suite."""
+"""Archive processor test suite."""
 
 import os
 
 import pytest
 
 from holocron import app
-from holocron.ext.processors import index
+from holocron.ext.processors import archive
 
 
 @pytest.fixture(scope='function')
@@ -13,10 +13,10 @@ def testapp():
     return app.Holocron()
 
 
-def test_document(testapp):
-    """Index processor has to work!"""
+def test_item(testapp):
+    """Archive processor has to work!"""
 
-    stream = index.process(
+    stream = archive.process(
         testapp,
         [
             {
@@ -33,10 +33,10 @@ def test_document(testapp):
 
     assert next(stream) == \
         {
-            'source': 'index://index.html',
+            'source': 'archive://index.html',
             'destination': 'index.html',
-            'template': 'index.j2',
-            'documents': [
+            'template': 'archive.j2',
+            'items': [
                 {
                     'title': 'the way of the Force',
                     'content': 'Obi-Wan'
@@ -49,10 +49,10 @@ def test_document(testapp):
 
 
 @pytest.mark.parametrize('amount', [0, 1, 2, 5, 10])
-def test_document_many(testapp, amount):
-    """Index processor has to work with stream."""
+def test_item_many(testapp, amount):
+    """archive processor has to work with stream."""
 
-    stream = index.process(
+    stream = archive.process(
         testapp,
         [
             {
@@ -69,10 +69,10 @@ def test_document_many(testapp, amount):
 
     assert next(stream) == \
         {
-            'source': 'index://index.html',
+            'source': 'archive://index.html',
             'destination': 'index.html',
-            'template': 'index.j2',
-            'documents': [
+            'template': 'archive.j2',
+            'items': [
                 {
                     'title': 'the way of the Force #%d' % i,
                 }
@@ -85,9 +85,9 @@ def test_document_many(testapp, amount):
 
 
 def test_param_template(testapp):
-    """Index processor has respect template parameter."""
+    """archive processor has respect template parameter."""
 
-    stream = index.process(
+    stream = archive.process(
         testapp,
         [
             {
@@ -105,10 +105,10 @@ def test_param_template(testapp):
 
     assert next(stream) == \
         {
-            'source': 'index://index.html',
+            'source': 'archive://index.html',
             'destination': 'index.html',
             'template': 'foobar.txt',
-            'documents': [
+            'items': [
                 {
                     'title': 'the way of the Force',
                     'content': 'Obi-Wan'
@@ -125,9 +125,9 @@ def test_param_template(testapp):
     os.path.join('yoda.jedi'),
 ])
 def test_param_save_as(testapp, save_as):
-    """Index processor has to respect save_as parameter."""
+    """archive processor has to respect save_as parameter."""
 
-    stream = index.process(
+    stream = archive.process(
         testapp,
         [
             {
@@ -145,10 +145,10 @@ def test_param_save_as(testapp, save_as):
 
     assert next(stream) == \
         {
-            'source': 'index://%s' % save_as,
+            'source': 'archive://%s' % save_as,
             'destination': save_as,
-            'template': 'index.j2',
-            'documents': [
+            'template': 'archive.j2',
+            'items': [
                 {
                     'title': 'the way of the Force',
                     'content': 'Obi-Wan'
@@ -165,7 +165,7 @@ def test_param_save_as(testapp, save_as):
     ({'template': 42}, "template: 42 should be instance of 'str'"),
 ])
 def test_param_bad_value(testapp, params, error):
-    """Index processor has to validate input parameters."""
+    """archive processor has to validate input parameters."""
 
     with pytest.raises(ValueError, match=error):
-        next(index.process(testapp, [], **params))
+        next(archive.process(testapp, [], **params))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -85,7 +85,7 @@ class TestHolocronDefaults(HolocronTestCase):
             'prettyuri',
             'feed',
             'sitemap',
-            'index',
+            'archive',
             'commit',
             'jinja2',
         ]))
@@ -205,7 +205,7 @@ class TestCreateApp(HolocronTestCase):
             'prettyuri',
             'feed',
             'sitemap',
-            'index',
+            'archive',
             'commit',
             'jinja2',
         ]))


### PR DESCRIPTION
Because it may be used to generate archive pages for a subset of
documents (thanks to when processor), and thus is suitable for more than
one use case.