### PR TITLE
Add 'str-to-datetime' processor

### DIFF
--- a/holocron/processors/source.py
+++ b/holocron/processors/source.py
@@ -57,14 +57,13 @@ def _finditems(app, path, pattern, encoding, tzinfo):
 
 
 def _createitem(app, path, basepath, encoding, tzinfo):
-    source = os.path.relpath(path, basepath)
-    item = _getinstance(source, app)
+    item = content.Document(app)
 
     # A path to an input (source) item. Despite reading its content into
     # a memory, we still want to have this attribute in order to do pattern
     # matching against it.
-    item['source'] = source
-    item['destination'] = source
+    item['source'] = os.path.relpath(path, basepath)
+    item['destination'] = item['source']
 
     item['created'] = \
         datetime.datetime.fromtimestamp(os.path.getctime(path), tzinfo)
@@ -78,22 +77,4 @@ def _createitem(app, path, basepath, encoding, tzinfo):
         with open(path, 'rb') as f:
             item['content'] = f.read()
 
-    return item
-
-
-def _getinstance(filename, app):
-    post_pattern = re.compile(r'^\d{2,4}/\d{1,2}/\d{1,2}')
-
-    # Extract 'published' date out of item path.
-    published = None
-    if post_pattern.search(filename):
-        published = ''.join(
-            post_pattern.search(filename).group(0).split(os.sep)[:3])
-        published = datetime.datetime.strptime(published, '%Y%m%d')
-
-    _, ext = os.path.splitext(filename)
-
-    item = content.Document(app)
-    if published:
-        item['published'] = published.date()
     return item

--- a/holocron/processors/todatetime.py
+++ b/holocron/processors/todatetime.py
@@ -1,0 +1,61 @@
+"""Convert string based value to a datetime instance."""
+
+import re
+
+import schema
+import dateutil.parser
+import dateutil.tz
+
+from ._misc import parameters
+
+
+@parameters(
+    fallback={
+        'timezone': 'metadata://#/timezone',
+    },
+    schema={
+        'todatetime': schema.Or(str, [str], error='unsupported todatetime'),
+        'parsearea': schema.Schema(re.compile, 'unsupported regexp'),
+        'timezone': schema.Schema(dateutil.tz.gettz, 'unsupported timezone'),
+        'fuzzy': schema.Schema(bool),
+    }
+)
+def process(app,
+            stream,
+            *,
+            todatetime,
+            parsearea='.*',
+            fuzzy=False,
+            timezone='UTC'):
+    tzinfo = dateutil.tz.gettz(timezone)
+    re_parsearea = re.compile(parsearea)
+
+    for item in stream:
+        # Todatetime option may be a string, which means convert and save a
+        # property under the same name, or pair, which means convert and save
+        # properties under the given names. The latter may be handy in cases
+        # when you want to extract a datetime string, let's say, from a
+        # filename.
+        if isinstance(todatetime, str):
+            parsein, saveto = todatetime, todatetime
+        else:
+            parsein, saveto = todatetime
+
+        # Reduce a parse area by applying a regular expression. May be handy
+        # if you want to extract a datetime information from a filename.
+        parsearea = re_parsearea.search(item[parsein])
+        if not parsearea:
+            raise RuntimeError(
+                "'parsearea' is not found in '%s' property: '%s' has no "
+                "occurance of '%s'" % (
+                    parsein, item[parsein], re_parsearea.pattern))
+        parsearea = parsearea.group(0)
+        converted = dateutil.parser.parse(parsearea, fuzzy=fuzzy)
+
+        # Attach passed timezone to a parsed datetime instance if tzinfo
+        # hasn't been found.
+        if not converted.tzinfo:
+            converted = converted.replace(tzinfo=tzinfo)
+        item[saveto] = converted
+
+        yield item

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
             'commit = holocron.processors.commit:process',
             'jinja2 = holocron.processors.jinja2:process',
             'when = holocron.processors.when:process',
+            'todatetime = holocron.processors.todatetime:process',
         ],
         'holocron.ext.commands': [
             'init = holocron.ext.commands.init:Init',

--- a/tests/processors/test_source.py
+++ b/tests/processors/test_source.py
@@ -1,7 +1,6 @@
 """Source processor test suite."""
 
 import os
-import datetime
 import unittest.mock
 
 import pytest
@@ -50,31 +49,6 @@ def test_item(testapp, monkeypatch, tmpdir, path):
             'content': 'Obi-Wan',
             'created': _pytest_timestamp(tmpdir.join(*path).stat().ctime),
             'updated': _pytest_timestamp(tmpdir.join(*path).stat().mtime),
-        }
-
-    with pytest.raises(StopIteration):
-        next(stream)
-
-
-@pytest.mark.parametrize('path, published', [
-    (('2017', '09', '17', 'cv.pdf'), datetime.date(2017, 9, 17)),
-    (('2018', '3', '2', 'cv.pdf'), datetime.date(2018, 3, 2)),
-])
-def test_item_published(testapp, monkeypatch, tmpdir, path, published):
-    """Source processor has to set published property for posts."""
-
-    monkeypatch.chdir(tmpdir)
-    tmpdir.ensure(*path).write_text('Obi-Wan', encoding='UTF-8')
-
-    stream = source.process(testapp, [])
-    assert next(stream) == \
-        {
-            'source': os.path.join(*path),
-            'destination': os.path.join(*path),
-            'content': 'Obi-Wan',
-            'created': _pytest_timestamp(tmpdir.join(*path).stat().ctime),
-            'updated': _pytest_timestamp(tmpdir.join(*path).stat().mtime),
-            'published': published,
         }
 
     with pytest.raises(StopIteration):

--- a/tests/processors/test_todatetime.py
+++ b/tests/processors/test_todatetime.py
@@ -1,0 +1,316 @@
+"""Todatetime processor test suite."""
+
+import datetime
+
+import pytest
+import dateutil.tz
+
+from holocron import app
+from holocron.processors import todatetime
+
+
+_TZ_UTC = dateutil.tz.gettz('UTC')
+_TZ_EET = dateutil.tz.gettz('EET')
+
+
+@pytest.fixture(scope='function')
+def testapp():
+    return app.Holocron()
+
+
+@pytest.mark.parametrize('timestamp, parsed', [
+    ('2019-01-15T21:07:07+00:00',
+     datetime.datetime(2019, 1, 15, 21, 7, 7, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07:07+00',
+     datetime.datetime(2019, 1, 15, 21, 7, 7, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07:07Z',
+     datetime.datetime(2019, 1, 15, 21, 7, 7, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07:07',
+     datetime.datetime(2019, 1, 15, 21, 7, 7, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07+00:00',
+     datetime.datetime(2019, 1, 15, 21, 7, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07+00',
+     datetime.datetime(2019, 1, 15, 21, 7, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07Z',
+     datetime.datetime(2019, 1, 15, 21, 7, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07',
+     datetime.datetime(2019, 1, 15, 21, 7, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21+00:00',
+     datetime.datetime(2019, 1, 15, 21, 0, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21+00',
+     datetime.datetime(2019, 1, 15, 21, 0, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21Z',
+     datetime.datetime(2019, 1, 15, 21, 0, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21',
+     datetime.datetime(2019, 1, 15, 21, 0, 0, tzinfo=_TZ_UTC)),
+    ('2019-01-15',
+     datetime.datetime(2019, 1, 15, 0, 0, 0, tzinfo=_TZ_UTC)),
+    ('20190115T210707Z',
+     datetime.datetime(2019, 1, 15, 21, 7, 7, tzinfo=_TZ_UTC)),
+    ('2019-01-15T21:07:07+02:00',
+     datetime.datetime(2019, 1, 15, 21, 7, 7, tzinfo=_TZ_EET)),
+    ('2019/01/11',
+     datetime.datetime(2019, 1, 11, 0, 0, 0, tzinfo=_TZ_UTC)),
+    ('01/11/2019',
+     datetime.datetime(2019, 1, 11, 0, 0, 0, tzinfo=_TZ_UTC)),
+    ('01-11-2019',
+     datetime.datetime(2019, 1, 11, 0, 0, 0, tzinfo=_TZ_UTC)),
+    ('01.11.2019',
+     datetime.datetime(2019, 1, 11, 0, 0, 0, tzinfo=_TZ_UTC)),
+])
+def test_item(testapp, timestamp, parsed):
+    """Todatetime processor has to work."""
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': timestamp,
+            },
+        ],
+        todatetime='timestamp')
+
+    assert next(stream) == \
+        {
+            'content': 'the Force is strong with this one',
+            'timestamp': parsed,
+        }
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+@pytest.mark.parametrize('amount', [0, 1, 2, 5, 10])
+def test_item_many(testapp, amount):
+    """Todatetime processor has to work with stream."""
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': '2019-01-%d' % (i + 1),
+            }
+            for i in range(amount)
+        ],
+        todatetime='timestamp')
+
+    for i, item in zip(range(amount), stream):
+        assert item == \
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': datetime.datetime(2019, 1, i + 1, tzinfo=_TZ_UTC),
+            }
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+def test_param_todatetime(testapp):
+    """Todatetime processor has to respect 'writeto' parameter."""
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': '2019-01-11',
+            },
+        ],
+        todatetime=['timestamp', 'published'])
+
+    assert next(stream) == \
+        {
+            'content': 'the Force is strong with this one',
+            'timestamp': '2019-01-11',
+            'published': datetime.datetime(
+                2019, 1, 11, 0, 0, 0, tzinfo=_TZ_UTC),
+        }
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+@pytest.mark.parametrize('timestamp, parsearea', [
+    ('2019/01/11/luke-skywalker-part-1.txt', r'\d{4}/\d{2}/\d{2}'),
+    ('2019-01-11-luke-skywalker-part-1.txt', r'\d{4}-\d{2}-\d{2}'),
+])
+def test_param_parsearea(testapp, timestamp, parsearea):
+    """Todatetime processor has to respect 'parsearea' parameter."""
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': timestamp,
+            },
+        ],
+        todatetime='timestamp',
+        parsearea=parsearea,
+        fuzzy=True)
+
+    assert next(stream) == \
+        {
+            'content': 'the Force is strong with this one',
+            'timestamp': datetime.datetime(2019, 1, 11, tzinfo=_TZ_UTC),
+        }
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+def test_param_parsearea_not_found(testapp):
+    """Todatetime processor has to respect 'parsearea' parameter."""
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': 'luke-skywalker-part-1.txt',
+            },
+        ],
+        todatetime='timestamp',
+        parsearea=r'\d{4}-\d{2}-\d{2}')
+
+    with pytest.raises(RuntimeError) as excinfo:
+        next(stream)
+
+    assert str(excinfo.value) == (
+        r"'parsearea' is not found in 'timestamp' property: "
+        r"'luke-skywalker-part-1.txt' has no occurance of "
+        r"'\d{4}-\d{2}-\d{2}'")
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+@pytest.mark.parametrize('timestamp', [
+    '2019/01/11/luke-skywalker.txt',
+    '2019/01/11/luke-skywalker/index.txt',
+    '/2019/01/11/luke-skywalker.txt',
+    '/2019/01/11/luke-skywalker/index.txt',
+    'http://example.com/2019/01/11/luke-skywalker.txt',
+    'http://example.com/2019/01/11/luke-skywalker/index.txt',
+    '2019-01-11-luke-skywalker.txt',
+    'posts/2019-01-11-luke-skywalker.txt',
+    '/posts/2019-01-11-luke-skywalker.txt',
+    'http://example.com/posts/2019-01-11-luke-skywalker.txt',
+])
+def test_param_fuzzy(testapp, timestamp):
+    """Todatetime processor has to respect 'fuzzy' parameter."""
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': timestamp,
+            },
+        ],
+        todatetime='timestamp',
+        fuzzy=True)
+
+    assert next(stream) == \
+        {
+            'content': 'the Force is strong with this one',
+            'timestamp': datetime.datetime(2019, 1, 11, tzinfo=_TZ_UTC),
+        }
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+@pytest.mark.parametrize('tz', ['EET', 'UTC'])
+def test_param_timezone(testapp, tz):
+    """Todatetime processor has to respect 'timezone' parameter."""
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': '2019-01-15T21:07+00:00',
+            },
+            {
+                'content': 'may the Force be with you',
+                'timestamp': '2019-01-15T21:07',
+            },
+        ],
+        todatetime='timestamp',
+
+        # Custom timezone has to be attached only to timestamps without
+        # explicit timezone information. So this option is nothing more
+        # but a fallback.
+        timezone=tz)
+
+    assert next(stream) == \
+        {
+            'content': 'the Force is strong with this one',
+            'timestamp': datetime.datetime(2019, 1, 15, 21, 7, tzinfo=_TZ_UTC),
+        }
+
+    assert next(stream) == \
+        {
+            'content': 'may the Force be with you',
+            'timestamp': datetime.datetime(
+                2019, 1, 15, 21, 7, tzinfo=dateutil.tz.gettz(tz))
+        }
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+@pytest.mark.parametrize('tz', ['EET', 'UTC'])
+def test_param_timezone_fallback(testapp, tz):
+    """Todatetime processor has to respect 'timezone' parameter (fallback)."""
+
+    # Custom timezone has to be attached only to timestamps without
+    # explicit timezone information. So this option is nothing more
+    # but a fallback.
+    testapp.metadata.update({'timezone': tz})
+
+    stream = todatetime.process(
+        testapp,
+        [
+            {
+                'content': 'the Force is strong with this one',
+                'timestamp': '2019-01-15T21:07+00:00',
+            },
+            {
+                'content': 'may the Force be with you',
+                'timestamp': '2019-01-15T21:07',
+            },
+        ],
+        todatetime='timestamp')
+
+    assert next(stream) == \
+        {
+            'content': 'the Force is strong with this one',
+            'timestamp': datetime.datetime(2019, 1, 15, 21, 7, tzinfo=_TZ_UTC),
+        }
+
+    assert next(stream) == \
+        {
+            'content': 'may the Force be with you',
+            'timestamp': datetime.datetime(
+                2019, 1, 15, 21, 7, tzinfo=dateutil.tz.gettz(tz))
+        }
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+@pytest.mark.parametrize('params, error', [
+    ({'todatetime': 42}, "todatetime: unsupported todatetime"),
+    ({'parsearea': 42}, "parsearea: unsupported regexp"),
+    ({'timezone': 'Europe/Kharkiv'}, 'timezone: unsupported timezone'),
+    ({'fuzzy': 42}, "fuzzy: 42 should be instance of 'bool'"),
+])
+def test_param_bad_value(testapp, params, error):
+    """Todatetime processor has to validate input parameters."""
+
+    with pytest.raises(ValueError, match=error):
+        next(todatetime.process(testapp, [], **params))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -70,6 +70,7 @@ class TestHolocronDefaults(HolocronTestCase):
             'commit',
             'jinja2',
             'when',
+            'todatetime',
         ]))
 
 
@@ -191,6 +192,7 @@ class TestCreateApp(HolocronTestCase):
             'commit',
             'jinja2',
             'when',
+            'todatetime',
         ]))
 
 


### PR DESCRIPTION
Strtodatetime processor is designed to convert and a string-based
timestamps to a Python's datetime instances, so they can later be used
by more *smart* processors, like feed.