### PR TITLE
Use 'core.Item()' instead of 'dict' in tests

### DIFF
--- a/tests/processors/test_commit.py
+++ b/tests/processors/test_commit.py
@@ -5,7 +5,7 @@ import os
 import py
 import pytest
 
-from holocron import app
+from holocron import app, core
 from holocron.processors import commit
 
 
@@ -22,17 +22,18 @@ def test_item(testapp, monkeypatch, tmpdir):
     stream = commit.process(
         testapp,
         [
-            {
-                "content": "Obi-Wan",
-                "destination": "1.html",
-            },
+            core.Item(
+                {
+                    "content": "Obi-Wan",
+                    "destination": "1.html",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "Obi-Wan",
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -52,17 +53,18 @@ def test_item_content_types(testapp, monkeypatch, tmpdir, data, loader):
     stream = commit.process(
         testapp,
         [
-            {
-                "content": data,
-                "destination": "1.dat",
-            },
+            core.Item(
+                {
+                    "content": data,
+                    "destination": "1.dat",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": data,
             "destination": "1.dat",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -84,17 +86,18 @@ def test_item_destination(testapp, monkeypatch, tmpdir, destination):
     stream = commit.process(
         testapp,
         [
-            {
-                "content": "Obi-Wan",
-                "destination": destination,
-            },
+            core.Item(
+                {
+                    "content": "Obi-Wan",
+                    "destination": destination,
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "Obi-Wan",
             "destination": destination,
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -111,19 +114,20 @@ def test_item_many(testapp, monkeypatch, tmpdir, amount):
     stream = commit.process(
         testapp,
         [
-            {
-                "content": "Obi-Wan",
-                "destination": str(i),
-            }
+            core.Item(
+                {
+                    "content": "Obi-Wan",
+                    "destination": str(i),
+                })
             for i in range(amount)
         ])
 
     for i in range(amount):
-        assert next(stream) == \
+        assert next(stream) == core.Item(
             {
                 "content": "Obi-Wan",
                 "destination": str(i),
-            }
+            })
         assert tmpdir.join("_site", str(i)).read_text("UTF-8") == "Obi-Wan"
 
     with pytest.raises(StopIteration):
@@ -139,18 +143,19 @@ def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
     stream = commit.process(
         testapp,
         [
-            {
-                "content": "Оби-Ван",
-                "destination": "1.html",
-            },
+            core.Item(
+                {
+                    "content": "Оби-Ван",
+                    "destination": "1.html",
+                }),
         ],
         encoding=encoding)
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "Оби-Ван",
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -168,17 +173,18 @@ def test_param_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
     stream = commit.process(
         testapp,
         [
-            {
-                "content": "Оби-Ван",
-                "destination": "1.html",
-            },
+            core.Item(
+                {
+                    "content": "Оби-Ван",
+                    "destination": "1.html",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "Оби-Ван",
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -195,18 +201,19 @@ def test_param_save_to(testapp, monkeypatch, tmpdir, save_to):
     stream = commit.process(
         testapp,
         [
-            {
-                "content": "Obi-Wan",
-                "destination": "1.html",
-            },
+            core.Item(
+                {
+                    "content": "Obi-Wan",
+                    "destination": "1.html",
+                }),
         ],
         save_to=save_to)
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "Obi-Wan",
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)

--- a/tests/processors/test_markdown.py
+++ b/tests/processors/test_markdown.py
@@ -6,7 +6,7 @@ import unittest.mock
 
 import pytest
 
-from holocron import app
+from holocron import app, core
 from holocron.processors import markdown
 
 
@@ -34,23 +34,24 @@ def test_item(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    # some title
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        # some title
 
-                    text with **bold**
-                """),
-                "destination": "1.md",
-            },
+                        text with **bold**
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text with <strong>bold</strong></p>"),
             "destination": "1.html",
             "title": "some title",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -62,24 +63,25 @@ def test_item_with_alt_title_syntax(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    some title
-                    ==========
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        some title
+                        ==========
 
-                    text with **bold**
-                """),
-                "destination": "1.md",
-            },
+                        text with **bold**
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text with <strong>bold</strong></p>"),
             "destination": "1.html",
             "title": "some title",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -91,25 +93,26 @@ def test_item_with_newlines_at_the_beginning(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
 
 
-                    # some title
+                        # some title
 
-                    text with **bold**
-                """),
-                "destination": "1.md",
-            },
+                        text with **bold**
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text with <strong>bold</strong></p>"),
             "destination": "1.html",
             "title": "some title",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -121,20 +124,21 @@ def test_item_without_title(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    text with **bold**
-                """),
-                "destination": "1.md",
-            },
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        text with **bold**
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text with <strong>bold</strong></p>"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -146,24 +150,25 @@ def test_item_title_is_not_overwritten(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    # some title
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        # some title
 
-                    text with **bold**
-                """),
-                "destination": "1.md",
-                "title": "another title",
-            },
+                        text with **bold**
+                    """),
+                    "destination": "1.md",
+                    "title": "another title",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text with <strong>bold</strong></p>"),
             "destination": "1.html",
             "title": "another title",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -175,26 +180,27 @@ def test_item_title_ignored_in_the_middle_of_text(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    text
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        text
 
-                    # some title
+                        # some title
 
-                    text with **bold**
-                """),
-                "destination": "1.md",
-            },
+                        text with **bold**
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text</p>\s*"
                 r"<h1>some title</h1>\s*"
                 r"<p>text with <strong>bold</strong></p>"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -206,36 +212,37 @@ def test_item_with_sections(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    some title 1
-                    ============
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        some title 1
+                        ============
 
-                    aaa
+                        aaa
 
-                    some section 1
-                    --------------
+                        some section 1
+                        --------------
 
-                    bbb
+                        bbb
 
-                    some section 2
-                    --------------
+                        some section 2
+                        --------------
 
-                    ccc
+                        ccc
 
-                    # some title 2
+                        # some title 2
 
-                    xxx
+                        xxx
 
-                    ## some section 3
+                        ## some section 3
 
-                    yyy
-                """),
-                "destination": "1.md",
-            },
+                        yyy
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>aaa</p>\s*"
@@ -245,7 +252,7 @@ def test_item_with_sections(testapp):
                 r"<h2>some section 3</h2>\s*<p>yyy</p>\s*"),
             "destination": "1.html",
             "title": "some title 1",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -257,23 +264,24 @@ def test_item_with_code(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    test codeblock
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        test codeblock
 
-                        :::python
-                        lambda x: pass
-                """),
-                "destination": "1.md",
-            },
+                            :::python
+                            lambda x: pass
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>test codeblock</p>\s*.*codehilite.*<pre>[\s\S]+</pre>.*"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -285,24 +293,25 @@ def test_item_with_fenced_code(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    test codeblock
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        test codeblock
 
-                    ```python
-                    lambda x: pass
-                    ```
-                """),
-                "destination": "1.md",
-            },
+                        ```python
+                        lambda x: pass
+                        ```
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>test codeblock</p>\s*.*codehilite.*<pre>[\s\S]+</pre>.*"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -314,22 +323,23 @@ def test_item_with_table(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    column a | column b
-                    ---------|---------
-                       foo   |   bar
-                """),
-                "destination": "1.md",
-            },
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        column a | column b
+                        ---------|---------
+                           foo   |   bar
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
     item = next(stream)
-    assert item == \
+    assert item == core.Item(
         {
             "content": unittest.mock.ANY,
             "destination": "1.html",
-        }
+        })
 
     assert "table" in item["content"]
     assert "<th>column a</th>" in item["content"]
@@ -347,19 +357,20 @@ def test_item_with_inline_code(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    test `code`
-                """),
-                "destination": "1.md",
-            },
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        test `code`
+                    """),
+                    "destination": "1.md",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(r"<p>test <code>code</code></p>"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -372,19 +383,20 @@ def test_item_many(testapp, amount):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": "the key is **%d**" % i,
-                "destination": "1.md",
-            }
+            core.Item(
+                {
+                    "content": "the key is **%d**" % i,
+                    "destination": "1.md",
+                })
             for i in range(amount)
         ])
 
     for i in range(amount):
-        assert next(stream) == \
+        assert next(stream) == core.Item(
             {
                 "content": "<p>the key is <strong>%d</strong></p>" % i,
                 "destination": "1.html",
-            }
+            })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -396,24 +408,25 @@ def test_param_extensions(testapp):
     stream = markdown.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    ```
-                    lambda x: pass
-                    ```
-                """),
-                "destination": "1.md",
-            },
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        ```
+                        lambda x: pass
+                        ```
+                    """),
+                    "destination": "1.md",
+                }),
         ],
         extensions=[])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 # no syntax highlighting when no extensions are passed
                 r"<p><code>lambda x: pass</code></p>"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)

--- a/tests/processors/test_metadata.py
+++ b/tests/processors/test_metadata.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from holocron import app
+from holocron import app, core
 from holocron.processors import metadata
 
 
@@ -17,22 +17,23 @@ def test_item(testapp):
     stream = metadata.process(
         testapp,
         [
-            {
-                "content": "the Force",
-                "author": "skywalker",
-            },
+            core.Item(
+                {
+                    "content": "the Force",
+                    "author": "skywalker",
+                }),
         ],
         metadata={
             "author": "yoda",
             "type": "memoire",
         })
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force",
             "author": "yoda",
             "type": "memoire",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -44,17 +45,18 @@ def test_item_untouched(testapp):
     stream = metadata.process(
         testapp,
         [
-            {
-                "content": "the Force",
-                "author": "skywalker",
-            },
+            core.Item(
+                {
+                    "content": "the Force",
+                    "author": "skywalker",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force",
             "author": "skywalker",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -67,10 +69,11 @@ def test_item_many(testapp, amount):
     stream = metadata.process(
         testapp,
         [
-            {
-                "content": "the key is #%d" % i,
-                "author": "luke",
-            }
+            core.Item(
+                {
+                    "content": "the key is #%d" % i,
+                    "author": "luke",
+                })
             for i in range(amount)
         ],
         metadata={
@@ -79,12 +82,12 @@ def test_item_many(testapp, amount):
         })
 
     for i in range(amount):
-        assert next(stream) == \
+        assert next(stream) == core.Item(
             {
                 "content": "the key is #%d" % i,
                 "author": "yoda",
                 "type": "memoire",
-            }
+            })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -100,10 +103,11 @@ def test_param_overwrite(testapp, overwrite, author):
     stream = metadata.process(
         testapp,
         [
-            {
-                "content": "the Force",
-                "author": "skywalker",
-            },
+            core.Item(
+                {
+                    "content": "the Force",
+                    "author": "skywalker",
+                }),
         ],
         metadata={
             "author": "yoda",
@@ -111,12 +115,12 @@ def test_param_overwrite(testapp, overwrite, author):
         },
         overwrite=overwrite)
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force",
             "author": author,
             "type": "memoire",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)

--- a/tests/processors/test_pipeline.py
+++ b/tests/processors/test_pipeline.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from holocron import app
+from holocron import app, core
 from holocron.processors import pipeline
 
 
@@ -20,7 +20,7 @@ def testapp():
 
     def rice(app, items, **options):
         yield from items
-        yield {"content": "rice"}
+        yield core.Item({"content": "rice"})
 
     instance = app.Holocron()
     instance.add_processor("spam", spam)
@@ -36,10 +36,11 @@ def test_item(testapp):
     stream = pipeline.process(
         testapp,
         [
-            {
-                "content": "the Force",
-                "author": "skywalker",
-            },
+            core.Item(
+                {
+                    "content": "the Force",
+                    "author": "skywalker",
+                }),
         ],
         pipeline=[
             {"name": "spam"},
@@ -47,17 +48,17 @@ def test_item(testapp):
             {"name": "rice"},
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force #friedeggs",
             "author": "skywalker",
             "spam": 42,
-        }
+        })
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "rice",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -69,21 +70,22 @@ def test_item_processor_with_option(testapp):
     stream = pipeline.process(
         testapp,
         [
-            {
-                "content": "the Force",
-                "author": "skywalker",
-            },
+            core.Item(
+                {
+                    "content": "the Force",
+                    "author": "skywalker",
+                }),
         ],
         pipeline=[
             {"name": "spam", "text": 1},
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force",
             "author": "skywalker",
             "spam": 1,
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -95,18 +97,19 @@ def test_param_pipeline_empty(testapp):
     stream = pipeline.process(
         testapp,
         [
-            {
-                "content": "the Force",
-                "author": "skywalker",
-            },
+            core.Item(
+                {
+                    "content": "the Force",
+                    "author": "skywalker",
+                }),
         ],
         pipeline=[])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force",
             "author": "skywalker",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -119,10 +122,11 @@ def test_item_many(testapp, amount):
     stream = pipeline.process(
         testapp,
         [
-            {
-                "content": "the Force (%d)" % i,
-                "author": "skywalker",
-            }
+            core.Item(
+                {
+                    "content": "the Force (%d)" % i,
+                    "author": "skywalker",
+                })
             for i in range(amount)
         ],
         pipeline=[
@@ -131,12 +135,12 @@ def test_item_many(testapp, amount):
         ])
 
     for i in range(amount):
-        assert next(stream) == \
+        assert next(stream) == core.Item(
             {
                 "content": "the Force (%d) #friedeggs" % i,
                 "author": "skywalker",
                 "spam": 42,
-            }
+            })
 
     with pytest.raises(StopIteration):
         next(stream)

--- a/tests/processors/test_prettyuri.py
+++ b/tests/processors/test_prettyuri.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from holocron import app
+from holocron import app, core
 from holocron.processors import prettyuri
 
 
@@ -19,15 +19,13 @@ def test_item(testapp):
     stream = prettyuri.process(
         testapp,
         [
-            {
-                "destination": os.path.join("about", "cv.html"),
-            },
+            core.Item({"destination": os.path.join("about", "cv.html")}),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "destination": os.path.join("about", "cv", "index.html"),
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -43,15 +41,13 @@ def test_item_index(testapp, index):
     stream = prettyuri.process(
         testapp,
         [
-            {
-                "destination": os.path.join("about", "cv", index),
-            },
+            core.Item({"destination": os.path.join("about", "cv", index)}),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "destination": os.path.join("about", "cv", index),
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -64,17 +60,15 @@ def test_item_many(testapp, amount):
     stream = prettyuri.process(
         testapp,
         [
-            {
-                "destination": os.path.join("about", "%d.html" % i),
-            }
+            core.Item({"destination": os.path.join("about", "%d.html" % i)})
             for i in range(amount)
         ])
 
     for i in range(amount):
-        assert next(stream) == \
+        assert next(stream) == core.Item(
             {
                 "destination": os.path.join("about", str(i), "index.html"),
-            }
+            })
 
     with pytest.raises(StopIteration):
         next(stream)

--- a/tests/processors/test_restructuredtext.py
+++ b/tests/processors/test_restructuredtext.py
@@ -5,7 +5,7 @@ import textwrap
 
 import pytest
 
-from holocron import app
+from holocron import app, core
 from holocron.processors import restructuredtext
 
 
@@ -33,24 +33,25 @@ def test_item(testapp):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    some title
-                    ==========
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        some title
+                        ==========
 
-                    text with **bold**
-                """),
-                "destination": "1.rst",
-            },
+                        text with **bold**
+                    """),
+                    "destination": "1.rst",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text with <strong>bold</strong></p>\s*"),
             "destination": "1.html",
             "title": "some title",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -62,23 +63,24 @@ def test_item_with_subsection(testapp):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    some title
-                    ==========
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        some title
+                        ==========
 
-                    abstract
+                        abstract
 
-                    some section
-                    ------------
+                        some section
+                        ------------
 
-                    text with **bold**
-                """),
-                "destination": "1.rst",
-            },
+                        text with **bold**
+                    """),
+                    "destination": "1.rst",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>abstract</p>\s*"
@@ -86,7 +88,7 @@ def test_item_with_subsection(testapp):
                 r"<p>text with <strong>bold</strong></p>\s*"),
             "destination": "1.html",
             "title": "some title",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -98,20 +100,21 @@ def test_item_without_title(testapp):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    text with **bold**
-                """),
-                "destination": "1.rst",
-            },
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        text with **bold**
+                    """),
+                    "destination": "1.rst",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>text with <strong>bold</strong></p>\s*"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -123,38 +126,39 @@ def test_item_with_sections(testapp):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    some title 1
-                    ============
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        some title 1
+                        ============
 
-                    aaa
+                        aaa
 
-                    some section 1
-                    --------------
+                        some section 1
+                        --------------
 
-                    bbb
+                        bbb
 
-                    some section 2
-                    --------------
+                        some section 2
+                        --------------
 
-                    ccc
+                        ccc
 
-                    some title 2
-                    ============
+                        some title 2
+                        ============
 
-                    xxx
+                        xxx
 
-                    some section 3
-                    --------------
+                        some section 3
+                        --------------
 
-                    yyy
-                """),
-                "destination": "1.rst",
-            },
+                        yyy
+                    """),
+                    "destination": "1.rst",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<h2>some title 1</h2>\s*"
@@ -168,7 +172,7 @@ def test_item_with_sections(testapp):
                 r"<h3>some section 3</h3>\s*"
                 r"<p>yyy</p>\s*"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -180,24 +184,25 @@ def test_item_with_code(testapp):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    test codeblock
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        test codeblock
 
-                    .. code:: python
+                        .. code:: python
 
-                        lambda x: pass
-                """),
-                "destination": "1.rst",
-            },
+                            lambda x: pass
+                    """),
+                    "destination": "1.rst",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 r"<p>test codeblock</p>\s*<pre.*python[^>]*>[\s\S]+</pre>"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -209,19 +214,20 @@ def test_item_with_inline_code(testapp):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    test ``code``
-                """),
-                "destination": "1.rst",
-            },
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        test ``code``
+                    """),
+                    "destination": "1.rst",
+                }),
         ])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(r"<p>test <code>code</code></p>"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -233,26 +239,27 @@ def test_param_settings(testapp):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": textwrap.dedent("""\
-                    section 1
-                    =========
+            core.Item(
+                {
+                    "content": textwrap.dedent("""\
+                        section 1
+                        =========
 
-                    aaa
+                        aaa
 
-                    section 2
-                    =========
+                        section 2
+                        =========
 
-                    bbb
-                """),
-                "destination": "1.rst",
-            },
+                        bbb
+                    """),
+                    "destination": "1.rst",
+                }),
         ],
         settings={
             "initial_header_level": 3,
         })
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": _pytest_regex(
                 # by default, initial header level is 2 and so the sections
@@ -262,7 +269,7 @@ def test_param_settings(testapp):
                 r"<h3>section 2</h3>\s*"
                 r"<p>bbb</p>\s*"),
             "destination": "1.html",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -275,19 +282,20 @@ def test_item_many(testapp, amount):
     stream = restructuredtext.process(
         testapp,
         [
-            {
-                "content": "the key is **%d**" % i,
-                "destination": "1.rst",
-            }
+            core.Item(
+                {
+                    "content": "the key is **%d**" % i,
+                    "destination": "1.rst",
+                })
             for i in range(amount)
         ])
 
     for i in range(amount):
-        assert next(stream) == \
+        assert next(stream) == core.Item(
             {
                 "content": "<p>the key is <strong>%d</strong></p>" % i,
                 "destination": "1.html",
-            }
+            })
 
     with pytest.raises(StopIteration):
         next(stream)

--- a/tests/processors/test_todatetime.py
+++ b/tests/processors/test_todatetime.py
@@ -5,7 +5,7 @@ import datetime
 import pytest
 import dateutil.tz
 
-from holocron import app
+from holocron import app, core
 from holocron.processors import todatetime
 
 
@@ -64,18 +64,19 @@ def test_item(testapp, timestamp, parsed):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": timestamp,
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": timestamp,
+                }),
         ],
         todatetime="timestamp")
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
             "timestamp": parsed,
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -88,20 +89,21 @@ def test_item_many(testapp, amount):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": "2019-01-%d" % (i + 1),
-            }
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": "2019-01-%d" % (i + 1),
+                })
             for i in range(amount)
         ],
         todatetime="timestamp")
 
     for i, item in zip(range(amount), stream):
-        assert item == \
+        assert item == core.Item(
             {
                 "content": "the Force is strong with this one",
                 "timestamp": datetime.datetime(2019, 1, i + 1, tzinfo=_TZ_UTC),
-            }
+            })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -113,16 +115,17 @@ def test_item_timestamp_missing(testapp):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                }),
         ],
         todatetime="timestamp")
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -134,10 +137,11 @@ def test_item_timestamp_bad_value(testapp):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": "yoda",
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": "yoda",
+                }),
         ],
         todatetime="timestamp")
 
@@ -155,20 +159,21 @@ def test_param_todatetime(testapp):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": "2019-01-11",
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": "2019-01-11",
+                }),
         ],
         todatetime=["timestamp", "published"])
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
             "timestamp": "2019-01-11",
             "published": datetime.datetime(
                 2019, 1, 11, 0, 0, 0, tzinfo=_TZ_UTC),
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -186,20 +191,21 @@ def test_param_parsearea(testapp, timestamp, parsearea):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": timestamp,
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": timestamp,
+                }),
         ],
         todatetime="timestamp",
         parsearea=parsearea,
         fuzzy=True)
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
             "timestamp": datetime.datetime(2019, 1, 11, tzinfo=_TZ_UTC),
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -211,19 +217,20 @@ def test_param_parsearea_not_found(testapp):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": "luke-skywalker-part-1.txt",
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": "luke-skywalker-part-1.txt",
+                }),
         ],
         todatetime="timestamp",
         parsearea=r"\d{4}-\d{2}-\d{2}")
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
             "timestamp": "luke-skywalker-part-1.txt",
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -247,19 +254,20 @@ def test_param_fuzzy(testapp, timestamp):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": timestamp,
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": timestamp,
+                }),
         ],
         todatetime="timestamp",
         fuzzy=True)
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
             "timestamp": datetime.datetime(2019, 1, 11, tzinfo=_TZ_UTC),
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -272,14 +280,16 @@ def test_param_timezone(testapp, tz):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": "2019-01-15T21:07+00:00",
-            },
-            {
-                "content": "may the Force be with you",
-                "timestamp": "2019-01-15T21:07",
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": "2019-01-15T21:07+00:00",
+                }),
+            core.Item(
+                {
+                    "content": "may the Force be with you",
+                    "timestamp": "2019-01-15T21:07",
+                }),
         ],
         todatetime="timestamp",
 
@@ -288,18 +298,18 @@ def test_param_timezone(testapp, tz):
         # but a fallback.
         timezone=tz)
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
             "timestamp": datetime.datetime(2019, 1, 15, 21, 7, tzinfo=_TZ_UTC),
-        }
+        })
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "may the Force be with you",
             "timestamp": datetime.datetime(
                 2019, 1, 15, 21, 7, tzinfo=dateutil.tz.gettz(tz))
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)
@@ -317,29 +327,31 @@ def test_param_timezone_fallback(testapp, tz):
     stream = todatetime.process(
         testapp,
         [
-            {
-                "content": "the Force is strong with this one",
-                "timestamp": "2019-01-15T21:07+00:00",
-            },
-            {
-                "content": "may the Force be with you",
-                "timestamp": "2019-01-15T21:07",
-            },
+            core.Item(
+                {
+                    "content": "the Force is strong with this one",
+                    "timestamp": "2019-01-15T21:07+00:00",
+                }),
+            core.Item(
+                {
+                    "content": "may the Force be with you",
+                    "timestamp": "2019-01-15T21:07",
+                }),
         ],
         todatetime="timestamp")
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "the Force is strong with this one",
             "timestamp": datetime.datetime(2019, 1, 15, 21, 7, tzinfo=_TZ_UTC),
-        }
+        })
 
-    assert next(stream) == \
+    assert next(stream) == core.Item(
         {
             "content": "may the Force be with you",
             "timestamp": datetime.datetime(
                 2019, 1, 15, 21, 7, tzinfo=dateutil.tz.gettz(tz))
-        }
+        })
 
     with pytest.raises(StopIteration):
         next(stream)


### PR DESCRIPTION
Recently 'core.Item()' class was added to Holocron as a replacement for
plain dict items passed from one processor to another. The class mostly
behaves like a dict, however, it differs in a way that provides auto
computed items. While passing a dict through a pipeline is still legit,
we better use a special class instead to focus on our end goal.