### PR TITLE
Replace 'Holocron' with 'core.Application'

### DIFF
--- a/src/holocron/__main__.py
+++ b/src/holocron/__main__.py
@@ -95,16 +95,6 @@ def parse_command_line(args):
     return arguments
 
 
-def run_pipeline(app, arguments):
-    if arguments.pipeline not in app.conf["pipelines"]:
-        raise ValueError("%s: no such pipeline" % arguments.pipeline)
-
-    pipeline = app.conf["pipelines"][arguments.pipeline]
-
-    for _ in app.invoke_processors([], pipeline):
-        pass
-
-
 def main(args=sys.argv[1:]):
     arguments = parse_command_line(args)
 
@@ -121,4 +111,5 @@ def main(args=sys.argv[1:]):
     if holocron is None:
         sys.exit(1)
 
-    run_pipeline(holocron, arguments)
+    for _ in holocron.invoke(arguments.pipeline):
+        pass

--- a/src/holocron/core/__init__.py
+++ b/src/holocron/core/__init__.py
@@ -1,6 +1,7 @@
 """Holocron core resides there."""
 
+from .application import Application
 from .items import Item, WebSiteItem
 
 
-__all__ = ["Item", "WebSiteItem"]
+__all__ = ["Application", "Item", "WebSiteItem"]

--- a/src/holocron/core/application.py
+++ b/src/holocron/core/application.py
@@ -1,0 +1,79 @@
+"""Holocron, The Application."""
+
+import collections
+
+from ..processors import _misc
+
+
+class Application:
+    """Application instance orchestrates processors execution."""
+
+    def __init__(self, metadata=None):
+        # Metadata is a KV store shared between processors. It serves two
+        # purposes: first, metadata contains an application level data, and
+        # secondly, it's the only way to consume artifacts produced by one
+        # processor from another processor.
+        #
+        # ChainMap is used to prevent writes to original metadata mapping,
+        # and thus making it easier to distinguish initial metadata values
+        # from the one set by processors in the mid of troubleshooting.
+        self._metadata = collections.ChainMap({}, metadata or {})
+
+        # Processors are (normally) stateless functions that receive an input
+        # stream of items and produce an output stream of items. This property
+        # keeps track of known processors, and is used to retrieve processors
+        # one someone asked to execute a pipeline.
+        self._processors = {}
+
+        # Pipelines are sets of processors connected in series, where the
+        # output of one processor is the input of the next one. This property
+        # keeps track of known pipelines, and is used to execute processors
+        # in sequence when invoked.
+        self._pipelines = {}
+
+    @property
+    def metadata(self):
+        return self._metadata
+
+    def add_processor(self, name, processor):
+        self._processors[name] = processor
+
+    def add_pipeline(self, name, pipeline):
+        self._pipelines[name] = pipeline
+
+    def invoke(self, pipeline, stream=None):
+        # A given 'pipeline' may be either a pipeline name or an actual
+        # pipeline definition. That's why need this ugly type check because any
+        # string value is considered as a name. Passing an actual pipeline is
+        # very handy in couple of use cases, such as running a sub pipeline
+        # from some processor.
+        if isinstance(pipeline, str):
+            if pipeline not in self._pipelines:
+                raise ValueError("no such pipeline: '%s'" % pipeline)
+            pipeline = self._pipelines[pipeline]
+
+        # Since processors expect an input stream to be an iterator, we cast a
+        # given stream explicitly to an iterator even though everything will
+        # probably work even if it's not. We just want to respect and enforce
+        # established contracts.
+        stream = iter(stream or [])
+
+        for processor in pipeline:
+            processor = processor.copy()
+            processor_name = processor.pop("name")
+
+            if processor_name not in self._processors:
+                raise ValueError("no such processor: '%s'" % processor_name)
+
+            processfn = self._processors[processor_name]
+
+            # Resolve every JSON reference we encounter in a processor's
+            # parameters. Please note, we're doing this so late because we
+            # want to take into account metadata and other changes produced
+            # by previous processors in the pipeline.
+            processor = _misc.resolve_json_references(
+                processor, {"metadata:": self.metadata})
+
+            stream = processfn(self, stream, **processor)
+
+        yield from stream

--- a/src/holocron/processors/pipeline.py
+++ b/src/holocron/processors/pipeline.py
@@ -11,4 +11,4 @@ from ._misc import parameters
     }
 )
 def process(app, stream, *, pipeline=[]):
-    yield from app.invoke_processors(stream, pipeline)
+    yield from app.invoke(pipeline, stream)

--- a/src/holocron/processors/when.py
+++ b/src/holocron/processors/when.py
@@ -40,7 +40,7 @@ def process(app, stream, *, when, processor):
             else:
                 untouched.append(item)
 
-    for item in app.invoke_processors(smartstream(), [processor]):
+    for item in app.invoke([processor], smartstream()):
         # Some untouched items may be collected during an attempt to retrieve
         # at least one item from a processor. In order to preserve relative
         # order between items from an original input stream and items produced

--- a/tests/core/test_application.py
+++ b/tests/core/test_application.py
@@ -1,0 +1,274 @@
+"""Core application test suite."""
+
+import pytest
+
+import holocron.core
+
+
+def test_metadata():
+    """.metadata property works like mapping."""
+
+    testapp = holocron.core.Application()
+
+    with pytest.raises(KeyError, match="'yoda'"):
+        testapp.metadata["yoda"]
+    assert testapp.metadata.get("yoda", "master") == "master"
+
+    testapp.metadata["yoda"] = "master"
+    assert testapp.metadata["yoda"] == "master"
+
+
+def test_metadata_init():
+    """.metadata property is initialized."""
+
+    testapp = holocron.core.Application({"yoda": "master", "vader": "sith"})
+
+    assert testapp.metadata["yoda"] == "master"
+    assert testapp.metadata["vader"] == "sith"
+
+    testapp.metadata["vader"] = "darth"
+    assert testapp.metadata["vader"] == "darth"
+    assert testapp.metadata["yoda"] == "master"
+
+
+def test_invoke():
+    """.invoke() just works!"""
+
+    def processor_a(app, items):
+        items = list(items)
+        assert items == [holocron.core.Item({"a": "b"})]
+        items[0]["x"] = 42
+        yield from items
+
+    def processor_b(app, items):
+        items = list(items)
+        assert items == [holocron.core.Item({"a": "b", "x": 42})]
+        items.append(holocron.core.Item({"z": 13}))
+        yield from items
+
+    def processor_c(app, items):
+        items = list(items)
+        assert items == [
+            holocron.core.Item({"a": "b", "x": 42}),
+            holocron.core.Item({"z": 13}),
+        ]
+        yield from items
+
+    testapp = holocron.core.Application()
+    testapp.add_processor("processor_a", processor_a)
+    testapp.add_processor("processor_b", processor_b)
+    testapp.add_processor("processor_c", processor_c)
+    testapp.add_pipeline(
+        "test",
+        [
+            {"name": "processor_a"},
+            {"name": "processor_b"},
+            {"name": "processor_c"},
+        ],
+    )
+
+    stream = testapp.invoke("test", [holocron.core.Item({"a": "b"})])
+    assert next(stream) == holocron.core.Item({"a": "b", "x": 42})
+    assert next(stream) == holocron.core.Item({"z": 13})
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+def test_invoke_anonymous_pipeline():
+    """.invoke() works with anonymous pipelines."""
+
+    def processor_a(app, items):
+        items = list(items)
+        assert items == [holocron.core.Item({"a": "b"})]
+        items[0]["x"] = 42
+        yield from items
+
+    def processor_b(app, items):
+        items = list(items)
+        assert items == [holocron.core.Item({"a": "b", "x": 42})]
+        items.append(holocron.core.Item({"z": 13}))
+        yield from items
+
+    def processor_c(app, items):
+        items = list(items)
+        assert items == [
+            holocron.core.Item({"a": "b", "x": 42}),
+            holocron.core.Item({"z": 13}),
+        ]
+        yield from items
+
+    testapp = holocron.core.Application()
+    testapp.add_processor("processor_a", processor_a)
+    testapp.add_processor("processor_b", processor_b)
+    testapp.add_processor("processor_c", processor_c)
+
+    stream = testapp.invoke(
+        [
+            {"name": "processor_a"},
+            {"name": "processor_b"},
+            {"name": "processor_c"},
+        ],
+        [
+            holocron.core.Item({"a": "b"})
+        ]
+    )
+
+    assert next(stream) == holocron.core.Item({"a": "b", "x": 42})
+    assert next(stream) == holocron.core.Item({"z": 13})
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+def test_invoke_pipeline_not_found():
+    """.invoke() raises proper exception."""
+
+    testapp = holocron.core.Application()
+
+    with pytest.raises(ValueError) as excinfo:
+        next(testapp.invoke("test"))
+
+    assert str(excinfo.value) == "no such pipeline: 'test'"
+
+
+def test_invoke_empty_pipeline():
+    """.invoke() returns nothing."""
+
+    testapp = holocron.core.Application()
+    testapp.add_pipeline("test", [])
+
+    with pytest.raises(StopIteration):
+        next(testapp.invoke("test"))
+
+
+def test_invoke_passthrough_items_empty_pipeline():
+    """.invoke() passes through items on empty pipeline."""
+
+    testapp = holocron.core.Application()
+    testapp.add_pipeline("test", [])
+
+    stream = testapp.invoke(
+        "test",
+        [
+            holocron.core.Item(name="yoda", rank="master"),
+            holocron.core.Item(name="skywalker"),
+        ],
+    )
+
+    assert next(stream) == holocron.core.Item(name="yoda", rank="master")
+    assert next(stream) == holocron.core.Item(name="skywalker")
+
+    with pytest.raises(StopIteration):
+        next(testapp.invoke("test"))
+
+
+def test_invoke_passthrough_items():
+    """.invoke() passes through items on non empty pipeline."""
+
+    def processor(app, items):
+        yield from items
+
+    testapp = holocron.core.Application()
+    testapp.add_processor("processor", processor)
+    testapp.add_pipeline("test", [{"name": "processor"}])
+
+    stream = testapp.invoke(
+        "test",
+        [
+            holocron.core.Item(name="yoda", rank="master"),
+            holocron.core.Item(name="skywalker"),
+        ],
+    )
+
+    assert next(stream) == holocron.core.Item(name="yoda", rank="master")
+    assert next(stream) == holocron.core.Item(name="skywalker")
+
+    with pytest.raises(StopIteration):
+        next(testapp.invoke("test"))
+
+
+@pytest.mark.parametrize(
+    "processor_options",
+    [
+        {"a": 1},
+        {"b": 1.13},
+        {"a": 1, "b": 1.13},
+        {"a": {"x": [1, 2]}, "b": ["1", 2]},
+    ],
+)
+def test_invoke_propagates_processor_options(processor_options):
+    """.invoke() propagates processor's options."""
+
+    def processor(app, items, **options):
+        assert options == processor_options
+        yield from items
+
+    testapp = holocron.core.Application()
+    testapp.add_processor("processor", processor)
+    testapp.add_pipeline("test", [dict(processor_options, name="processor")])
+
+    with pytest.raises(StopIteration):
+        next(testapp.invoke("test"))
+
+
+@pytest.mark.parametrize("options, resolved", [
+    ({"a": {"$ref": "metadata://#/is_yoda_master"}}, {"a": True}),
+    ({"a": {"$ref": "metadata://#/extra/0/luke"}}, {"a": "skywalker"}),
+    ({"a": {"$ref": "metadata://#/is_yoda_master"},
+      "b": {"$ref": "metadata://#/extra/0/luke"}},
+     {"a": True, "b": "skywalker"}),
+    ({"a": {"$ref": "item://#/content"}},
+     {"a": {"$ref": "item://#/content"}}),
+])
+def test_invoke_resolves_jsonref(options, resolved):
+    """.invoke() resolves JSON references in processor's options."""
+
+    testapp = holocron.core.Application(
+        {
+            "extra": [{"luke": "skywalker"}],
+            "is_yoda_master": True,
+        },
+    )
+
+    def processor(app, items, **options):
+        assert options == resolved
+        yield from items
+
+    testapp.add_processor("processor", processor)
+    testapp.add_pipeline("test", [dict(options, name="processor")])
+
+    with pytest.raises(StopIteration):
+        next(testapp.invoke("test"))
+
+
+def test_invoke_processor_errors():
+    """.invoke() raises proper exception."""
+
+    def processor(app, documents):
+        raise ValueError("something bad happened")
+        yield
+
+    testapp = holocron.core.Application()
+    testapp.add_processor("processor", processor)
+    testapp.add_pipeline("test", [{"name": "processor"}])
+
+    stream = testapp.invoke("test")
+
+    with pytest.raises(ValueError, match=r"^something bad happened$"):
+        next(stream)
+
+    with pytest.raises(StopIteration):
+        next(stream)
+
+
+def test_invoke_processor_not_found():
+    """.invoke() raises proper exception."""
+
+    testapp = holocron.core.Application()
+    testapp.add_pipeline("test", [{"name": "processor"}])
+
+    with pytest.raises(ValueError) as excinfo:
+        next(testapp.invoke("test"))
+
+    assert str(excinfo.value) == "no such processor: 'processor'"

--- a/tests/processors/test_archive.py
+++ b/tests/processors/test_archive.py
@@ -4,13 +4,13 @@ import os
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import archive
 
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron(metadata={"url": "https://yoda.ua"})
+    return core.Application({"url": "https://yoda.ua"})
 
 
 def test_item(testapp):

--- a/tests/processors/test_commit.py
+++ b/tests/processors/test_commit.py
@@ -5,13 +5,13 @@ import os
 import py
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import commit
 
 
 @pytest.fixture(scope="function")
 def testapp(request):
-    return app.Holocron()
+    return core.Application()
 
 
 def test_item(testapp, monkeypatch, tmpdir):

--- a/tests/processors/test_feed.py
+++ b/tests/processors/test_feed.py
@@ -8,7 +8,7 @@ import pkg_resources
 import pytest
 import untangle
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import feed
 
 
@@ -17,7 +17,7 @@ _HOLOCRON_VERSION = pkg_resources.get_distribution("holocron").version
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron(metadata={"url": "https://yoda.ua"})
+    return core.Application({"url": "https://yoda.ua"})
 
 
 def test_item_atom(testapp):

--- a/tests/processors/test_frontmatter.py
+++ b/tests/processors/test_frontmatter.py
@@ -5,13 +5,13 @@ import textwrap
 import pytest
 import yaml
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import frontmatter
 
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron()
+    return core.Application()
 
 
 def test_item(testapp):

--- a/tests/processors/test_jinja2.py
+++ b/tests/processors/test_jinja2.py
@@ -7,13 +7,13 @@ import unittest.mock
 import pytest
 import bs4
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import jinja2
 
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron(metadata={"url": "https://yoda.ua"})
+    return core.Application({"url": "https://yoda.ua"})
 
 
 def test_item(testapp):

--- a/tests/processors/test_markdown.py
+++ b/tests/processors/test_markdown.py
@@ -6,7 +6,7 @@ import unittest.mock
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import markdown
 
 
@@ -25,7 +25,7 @@ class _pytest_regex:
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron()
+    return core.Application()
 
 
 def test_item(testapp):

--- a/tests/processors/test_metadata.py
+++ b/tests/processors/test_metadata.py
@@ -2,13 +2,13 @@
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import metadata
 
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron()
+    return core.Application()
 
 
 def test_item(testapp):

--- a/tests/processors/test_pipeline.py
+++ b/tests/processors/test_pipeline.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import pipeline
 
 
@@ -22,7 +22,7 @@ def testapp():
         yield from items
         yield core.Item({"content": "rice"})
 
-    instance = app.Holocron()
+    instance = core.Application()
     instance.add_processor("spam", spam)
     instance.add_processor("eggs", eggs)
     instance.add_processor("rice", rice)

--- a/tests/processors/test_prettyuri.py
+++ b/tests/processors/test_prettyuri.py
@@ -4,13 +4,13 @@ import os
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import prettyuri
 
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron()
+    return core.Application()
 
 
 def test_item(testapp):

--- a/tests/processors/test_restructuredtext.py
+++ b/tests/processors/test_restructuredtext.py
@@ -5,7 +5,7 @@ import textwrap
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import restructuredtext
 
 
@@ -24,7 +24,7 @@ class _pytest_regex:
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron()
+    return core.Application()
 
 
 def test_item(testapp):

--- a/tests/processors/test_sitemap.py
+++ b/tests/processors/test_sitemap.py
@@ -8,7 +8,7 @@ import unittest.mock
 import pytest
 import xmltodict
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import sitemap
 
 
@@ -31,7 +31,7 @@ class _pytest_xmlasdict:
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron(metadata={"url": "https://yoda.ua"})
+    return core.Application({"url": "https://yoda.ua"})
 
 
 @pytest.mark.parametrize("filename, escaped", [

--- a/tests/processors/test_source.py
+++ b/tests/processors/test_source.py
@@ -5,7 +5,7 @@ import unittest.mock
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import source
 
 
@@ -26,7 +26,7 @@ class _pytest_timestamp:
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron(metadata={"url": "https://yoda.ua"})
+    return core.Application({"url": "https://yoda.ua"})
 
 
 @pytest.mark.parametrize("path", [

--- a/tests/processors/test_todatetime.py
+++ b/tests/processors/test_todatetime.py
@@ -5,7 +5,7 @@ import datetime
 import pytest
 import dateutil.tz
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import todatetime
 
 
@@ -15,7 +15,7 @@ _TZ_EET = dateutil.tz.gettz("EET")
 
 @pytest.fixture(scope="function")
 def testapp():
-    return app.Holocron()
+    return core.Application()
 
 
 @pytest.mark.parametrize("timestamp, parsed", [

--- a/tests/processors/test_when.py
+++ b/tests/processors/test_when.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from holocron import app, core
+from holocron import core
 from holocron.processors import when
 
 
@@ -29,7 +29,7 @@ def testapp(request):
             else:
                 yield core.Item({"key": item_a["key"] + item_b["key"]})
 
-    instance = app.Holocron()
+    instance = core.Application()
     instance.add_processor("spam", spam)
     instance.add_processor("rice", rice)
     instance.add_processor("eggs", eggs)


### PR DESCRIPTION
core.Application() is mostly the same as what 'Holocron' is used to be
for the past months (master branch, obviosly), however, its internals
are thoroughly designed and covered with tests. From now one, this is
one and only way to run pipelines.