### PR TITLE
todatetime: cast path instace to str

### DIFF
--- a/src/holocron/_processors/todatetime.py
+++ b/src/holocron/_processors/todatetime.py
@@ -1,5 +1,6 @@
 """Convert string based value to a datetime instance."""
 
+import pathlib
 import re
 
 import dateutil.parser
@@ -50,11 +51,19 @@ def process(
             yield item
             continue
 
+        parsein = item[parsein]
+
+        # Cast the path object to string for user, because it's a behaviour a
+        # user would expect anyway. Besides, I personally require such
+        # behaviour because I prefer to have a datetime encoded in path.
+        if isinstance(parsein, pathlib.Path):
+            parsein = str(parsein)
+
         # Reduce a parse area by applying a regular expression. May be handy if
         # you want to extract a datetime from, let's say, a filename. If a
         # regular expression matches nothing, ignore and skip an item to avoid
         # using 'when' processor to make things *safe*.
-        parsearea = re_parsearea.search(item[parsein])
+        parsearea = re_parsearea.search(parsein)
         if not parsearea:
             yield item
             continue

--- a/tests/_processors/test_todatetime.py
+++ b/tests/_processors/test_todatetime.py
@@ -2,6 +2,7 @@
 
 import collections.abc
 import datetime
+import pathlib
 
 import pytest
 import dateutil.tz
@@ -204,7 +205,14 @@ def test_item_timestamp_bad_value(testapp):
         assert str(excinfo.value) == "('Unknown string format:', 'yoda')"
 
 
-def test_param_todatetime(testapp):
+@pytest.mark.parametrize(
+    ["timestamp"],
+    [
+        pytest.param("2019-01-11", id="str"),
+        pytest.param(pathlib.Path("2019-01-11"), id="path"),
+    ],
+)
+def test_param_todatetime(testapp, timestamp):
     """Todatetime processor has to respect "writeto" parameter."""
 
     stream = todatetime.process(
@@ -213,7 +221,7 @@ def test_param_todatetime(testapp):
             holocron.Item(
                 {
                     "content": "the Force is strong with this one",
-                    "timestamp": "2019-01-11",
+                    "timestamp": timestamp,
                 }
             )
         ],
@@ -225,7 +233,7 @@ def test_param_todatetime(testapp):
         holocron.Item(
             {
                 "content": "the Force is strong with this one",
-                "timestamp": "2019-01-11",
+                "timestamp": timestamp,
                 "published": datetime.datetime(
                     2019, 1, 11, 0, 0, 0, tzinfo=_TZ_UTC
                 ),


### PR DESCRIPTION
Since it's a common use case when a user wants to retrieve published date from a path on filesystem, we probably should cast Python's path instance to str before trying to parse it as a datetime.