### PR TITLE
frontmatter: json/toml are now supported formats

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -416,9 +416,8 @@ python-versions = "*"
 version = "1.1.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python Library for Tom's Obvious, Minimal Language"
-marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "toml"
 optional = false
 python-versions = "*"
@@ -469,7 +468,7 @@ python-versions = ">=2.7"
 version = "0.5.1"
 
 [metadata]
-content-hash = "f22f22b78feeec2cf1f1155125638d0edf8fd9cccc85ae8fff391fe73a499773"
+content-hash = "5deeb47e61fe69c88529e34890448934a814f56508eb99673af018b70cf3f2b1"
 python-versions = "^3.6"
 
 [metadata.hashes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ termcolor = "^1.1"
 colorama = "^0.4.1"
 mistletoe = "^0.7.1"
 jsonschema = { version = "^3.0", extras = ["format"] }
+toml = {version = "^0.10.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 mock = "^2.0"

--- a/src/holocron/_processors/frontmatter.py
+++ b/src/holocron/_processors/frontmatter.py
@@ -1,10 +1,70 @@
 """Parse YAML front matter and set its values as item"s properties."""
 
+import collections.abc
+import json
 import re
 
-import yaml
-
 from ._misc import parameters
+
+
+class _FrontmatterParser:
+    """Parse frontmatter using one of the supported formats."""
+
+    def __init__(self, format):
+        self._parsers = {"json": json.loads}
+        self._try_next_exceptions = [json.JSONDecodeError]
+        self._format = format
+
+        try:
+            import toml
+        except ImportError:
+            pass
+        else:
+            self._parsers["toml"] = toml.loads
+            self._try_next_exceptions.append(toml.TomlDecodeError)
+
+        try:
+            import yaml
+        except ImportError:
+            pass
+        else:
+            # YAML is too eager and can parse TOML as plain YAML string. Since
+            # frontmatter must be a mapping, it's not what a user would expect.
+            # In order to prevent such issues, we must ensure that YAML parser
+            # goes last.
+            self._parsers["yaml"] = yaml.safe_load
+            self._try_next_exceptions.append(yaml.YAMLError)
+
+        # If a user passed the format of frontmatter, we can save some CPU
+        # cycles and avoid parsing using other available parsers. Moreover,
+        # specifying the format explicitly may result into returning better
+        # error.
+        if self._format:
+            self._parsers = {self._format: self._parsers[self._format]}
+
+    def __call__(self, frontmatter):
+        for format, parse in self._parsers.items():
+            try:
+                rv = parse(frontmatter)
+            except tuple(self._try_next_exceptions):
+                # If there's only one parser to try, we can propagate its
+                # exception up above in order to provide more context
+                # regarding the error.
+                if self._format:
+                    raise
+                continue
+
+            if not isinstance(rv, collections.abc.Mapping):
+                raise ValueError(
+                    "Frontmatter must be a mapping (i.e. key-value pairs), "
+                    "not arrays."
+                )
+            return rv
+
+        raise ValueError(
+            f"Frontmatter cannot be parsed as one of the supported formats: "
+            f"{', '.join(self._parsers)}"
+        )
 
 
 @parameters(
@@ -13,11 +73,13 @@ from ._misc import parameters
         "properties": {
             "delimiter": {"type": "string"},
             "overwrite": {"type": "boolean"},
+            "format": {"type": "string", "enum": ["yaml", "json", "toml"]},
         },
     }
 )
-def process(app, stream, *, delimiter="---", overwrite=True):
+def process(app, stream, *, delimiter="---", overwrite=True, format=None):
     delimiter = re.escape(delimiter)
+    parser = _FrontmatterParser(format)
 
     for item in stream:
         match = re.match(
@@ -29,9 +91,9 @@ def process(app, stream, *, delimiter="---", overwrite=True):
         )
 
         if match:
-            headers, item["content"] = match.groups()
+            frontmatter, item["content"] = match.groups()
 
-            for key, value in yaml.safe_load(headers).items():
+            for key, value in parser(frontmatter).items():
                 if overwrite or key not in item:
                     item[key] = value
 


### PR DESCRIPTION
Frontmatter processor now supports TOML and JSON frontmatters. Because TOML is new sexy outta here, and JSON is what we have out of the box in Python. This is both a feature that extends frontmatter processor and a small step towards make pyyaml optional.