### PR TITLE
Pass theme options via jinja2's context

### DIFF
--- a/src/holocron/__main__.py
+++ b/src/holocron/__main__.py
@@ -180,6 +180,9 @@ def main(args=sys.argv[1:]):
                     termcolor.colored("==>", "green", attrs=["bold"]),
                     termcolor.colored(item["destination"], attrs=["bold"]),
                 )
-        except Exception as exc:
+        except (RuntimeError, IsADirectoryError) as exc:
             print(str(exc), file=sys.stderr)
+            sys.exit(1)
+        except Exception:
+            logging.getLogger().exception("Oops.. something went wrong.")
             sys.exit(1)

--- a/src/holocron/_processors/_misc.py
+++ b/src/holocron/_processors/_misc.py
@@ -25,6 +25,9 @@ def resolve_json_references(value, context, keep_unknown=True):
         elif isinstance(node, collections.abc.Sequence) and not isinstance(
             node, str
         ):
+            if not isinstance(node, collections.abc.MutableSequence):
+                node = list(node)
+
             for i in range(len(node)):
                 node[i] = _do_resolve(node[i])
         return node

--- a/src/holocron/_processors/jinja2/__init__.py
+++ b/src/holocron/_processors/jinja2/__init__.py
@@ -20,6 +20,12 @@ from .._misc import parameters
     }
 )
 def process(app, stream, *, template="item.j2", context={}, themes=None):
+    # Because it is easier to write themes if we assume that 'theme' variable
+    # is always defined in context of template, let's ensure it is always
+    # defined indeed. Frankly, I'm not exactly sure about this line and it may
+    # change in the future.
+    context.setdefault("theme", {})
+
     if themes is None:
         themes = [str(pathlib.Path(__file__).parent / "theme")]
 

--- a/src/holocron/_processors/jinja2/theme/templates/_base.j2
+++ b/src/holocron/_processors/jinja2/theme/templates/_base.j2
@@ -22,7 +22,7 @@
     <a href="/" class="title">{{ metadata.title }}</a>
 
     <nav>
-      {% for name, url in metadata | jsonpointer("/theme/navigation", []) -%}
+      {% for name, url in theme | jsonpointer("/navigation", []) -%}
         <a href="{{ url }}">{{ name }}</a>
       {%- endfor %}
     </nav>
@@ -38,13 +38,13 @@
 
   <div class="footer-wrapper">
   <footer class="footer">
-    <p>{{ metadata | jsonpointer("/theme/copyright", "") }}</p>
+    <p>{{ theme | jsonpointer("/copyright", "") }}</p>
   </footer>
   </div> <!-- /.footer-wrapper -->
 
-  {% if metadata | jsonpointer("/theme/ribbon", None) %}
-    <a href="{{ metadata.theme.ribbon.link }}" class="ribbon">
-      {{ metadata.theme.ribbon.text }}
+  {% if theme | jsonpointer("/ribbon", None) %}
+    <a href="{{ theme.ribbon.link }}" class="ribbon">
+      {{ theme.ribbon.text }}
     </a>
   {% endif %}
 

--- a/src/holocron/_processors/jinja2/theme/templates/_counters.j2
+++ b/src/holocron/_processors/jinja2/theme/templates/_counters.j2
@@ -1,10 +1,10 @@
-{% if metadata | jsonpointer('/theme/counters/yandex_metrika', None) -%}
+{% if theme | jsonpointer('/counters/yandex_metrika', None) -%}
 <!-- Yandex.Metrika counter -->
 <script type="text/javascript">
 (function (d, w, c) {
     (w[c] = w[c] || []).push(function() {
         try {
-            w.yaCounter{{ metadata.theme.counters.yandex_metrika }} = new Ya.Metrika({id:{{ metadata.theme.counters.yandex_metrika }}, enableAll: true});
+            w.yaCounter{{ theme.counters.yandex_metrika }} = new Ya.Metrika({id:{{ theme.counters.yandex_metrika }}, enableAll: true});
         } catch(e) {}
     });
 
@@ -20,11 +20,11 @@
     } else { f(); }
 })(document, window, "yandex_metrika_callbacks");
 </script>
-<noscript><div><img src="//mc.yandex.ru/watch/{{ metadata.theme.counters.yandex_metrika }}" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+<noscript><div><img src="//mc.yandex.ru/watch/{{ theme.counters.yandex_metrika }}" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
 <!-- /Yandex.Metrika counter -->
 {%- endif %}
 
-{% if metadata | jsonpointer('/theme/counters/google_analytics', None) -%}
+{% if theme | jsonpointer('/counters/google_analytics', None) -%}
 <!-- Google Analytics -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -32,7 +32,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '{{ metadata.theme.counters.google_analytics }}', 'auto');
+  ga('create', '{{ theme.counters.google_analytics }}', 'auto');
   ga('send', 'pageview');
 </script>
 <!-- /Google Analytics -->

--- a/src/holocron/_processors/jinja2/theme/templates/item.j2
+++ b/src/holocron/_processors/jinja2/theme/templates/item.j2
@@ -15,9 +15,9 @@
     <meta name="description" content="{{ summary }}">
   {%- endif %}
 
-  {% if metadata | jsonpointer("/theme/twitter_cards/username", None) and item.summary -%}
+  {% if theme | jsonpointer("/twitter_cards/username", None) and item.summary -%}
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:site" content="@{{ metadata.theme.twitter_cards.username }}">
+    <meta name="twitter:site" content="@{{ theme.twitter_cards.username }}">
     <meta name="twitter:title" content="{{ item.title }}">
     <meta name="twitter:description" content="{{ summary }}">
   {% endif %}


### PR DESCRIPTION
Processors must be as isolated as possible and hence do not rely on
things stored in metadata. If one wants to store something in metadata,
JSON reference must be used to tell processor to go and check metadata
instead.

That said, this commit moves theme options from metadata to jinja2's
processor context.