### PR TITLE
Show emitted logs at the very end of execution

### DIFF
--- a/src/holocron/_processors/_misc.py
+++ b/src/holocron/_processors/_misc.py
@@ -2,11 +2,15 @@
 
 import collections.abc
 import inspect
+import logging
 import functools
 import urllib.parse
 
 import jsonschema
 import jsonpointer
+
+
+_logger = logging.getLogger("holocron")
 
 
 def resolve_json_references(value, context, keep_unknown=True):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,13 +1,21 @@
 """Tests Holocron CLI."""
 
+import logging
 import pathlib
+import subprocess
 import sys
 import textwrap
-import subprocess
 
 import mock
 import pytest
 import yaml
+
+
+@pytest.fixture(autouse=True)
+def _fake_root_logger(monkeypatch):
+    """Prevent modifying global root instance."""
+
+    monkeypatch.setattr(logging, "root", logging.getLogger("fakeroot"))
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Because in Holocron, we want to show logs at the very end of usual
output and only if a user explicitly asked for it.