### PR TITLE
Add 'chain' processor

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -230,13 +230,12 @@ pbr = ">=0.11"
 six = ">=1.9"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "More routines for operating on iterables, beyond itertools"
-marker = "python_version > \"2.7\""
 name = "more-itertools"
 optional = false
 python-versions = ">=3.4"
-version = "7.1.0"
+version = "7.2.0"
 
 [[package]]
 category = "dev"
@@ -468,7 +467,7 @@ python-versions = ">=2.7"
 version = "0.5.1"
 
 [metadata]
-content-hash = "5deeb47e61fe69c88529e34890448934a814f56508eb99673af018b70cf3f2b1"
+content-hash = "f5979e4551f400576fb86930c092e1489d0cb6dade10a2bd366b7266d7d872ba"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -495,7 +494,7 @@ markupsafe = ["00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"
 mccabe = ["ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"]
 mistletoe = ["24d0f18cc5f0381c2cfb8a24ef3de83eb9f7929cb7d0e71ecb164b671d86e6a3", "3e2d31b2fa6231ea2ee46981274ebac8d5e5736e3aad2d1cd449e2c053b7023b"]
 mock = ["5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1", "b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"]
-more-itertools = ["3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d", "8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"]
+more-itertools = ["409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
 packaging = ["0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af", "9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"]
 pbr = ["36ebd78196e8c9588c972f5571230a059ff83783fabbbbedecc07be263ccd7e6", "5a03f59455ad54f01a94c15829b8b70065462b7bd8d5d7e983306b59127fc841"]
 pluggy = ["0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc", "b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ colorama = "^0.4.1"
 mistletoe = "^0.7.1"
 jsonschema = { version = "^3.0", extras = ["format"] }
 toml = {version = "^0.10.0", optional = true}
+more-itertools = "^7.2"
 
 [tool.poetry.dev-dependencies]
 mock = "^2.0"

--- a/src/holocron/_processors/chain.py
+++ b/src/holocron/_processors/chain.py
@@ -1,0 +1,42 @@
+"""Chain and order stream of items."""
+
+import operator
+
+import more_itertools
+
+from ._misc import parameters
+
+
+@parameters(
+    jsonschema={
+        "type": "object",
+        "properties": {
+            "order_by": {"type": "string"},
+            "direction": {"type": "string", "enum": ["asc", "desc"]},
+        },
+    }
+)
+def process(app, stream, *, order_by=None, direction=None):
+    if direction and not order_by:
+        raise ValueError("'direction' cannot be set without 'order_by'")
+
+    if order_by:
+        # WARNING: Sorting the stream requires evaluating all items from the
+        # stream. This alone sets a requirement that all items must fit into,
+        # which may not be achievable in certain cases.
+        stream = sorted(
+            stream,
+            key=operator.itemgetter(order_by),
+            reverse=direction == "desc",
+        )
+
+    for prev, curr in more_itertools.windowed(stream, 2):
+        if curr:
+            curr["prev"] = prev
+            prev["next"] = curr
+
+        if prev:
+            yield prev
+
+    if curr:
+        yield curr

--- a/tests/_processors/test_chain.py
+++ b/tests/_processors/test_chain.py
@@ -1,0 +1,210 @@
+"""Chain processor test suite."""
+
+import collections.abc
+
+import pytest
+
+import holocron
+from holocron._processors import chain
+
+
+@pytest.fixture(scope="function")
+def testapp():
+    return holocron.Application()
+
+
+def test_one_item(testapp):
+    """Chain processor has to work with one item!"""
+
+    stream = chain.process(
+        testapp, [holocron.Item({"title": "The Force", "content": "Obi-Wan"})]
+    )
+
+    assert isinstance(stream, collections.abc.Iterable)
+    assert list(stream) == [
+        holocron.Item({"title": "The Force", "content": "Obi-Wan"})
+    ]
+
+
+def test_two_items(testapp):
+    """Chain processor has to work with two items!"""
+
+    stream = chain.process(
+        testapp,
+        [
+            holocron.Item({"title": "The Force", "content": "Obi-Wan"}),
+            holocron.Item({"title": "Force, The", "content": "Yoda"}),
+        ],
+    )
+
+    assert isinstance(stream, collections.abc.Iterable)
+    items = list(stream)
+
+    assert items == [
+        holocron.Item(
+            {"title": "The Force", "content": "Obi-Wan", "next": items[1]}
+        ),
+        holocron.Item(
+            {"title": "Force, The", "content": "Yoda", "prev": items[0]}
+        ),
+    ]
+
+
+def test_three_items(testapp):
+    """Chain processor has to work with three items!"""
+
+    stream = chain.process(
+        testapp,
+        [
+            holocron.Item({"title": "The Force", "content": "Obi-Wan"}),
+            holocron.Item({"title": "Force, The", "content": "Yoda"}),
+            holocron.Item({"title": "The Dark Side", "content": "Vader"}),
+        ],
+    )
+
+    assert isinstance(stream, collections.abc.Iterable)
+    items = list(stream)
+
+    assert items == [
+        holocron.Item(
+            {"title": "The Force", "content": "Obi-Wan", "next": items[1]}
+        ),
+        holocron.Item(
+            {
+                "title": "Force, The",
+                "content": "Yoda",
+                "prev": items[0],
+                "next": items[2],
+            }
+        ),
+        holocron.Item(
+            {"title": "The Dark Side", "content": "Vader", "prev": items[1]}
+        ),
+    ]
+
+
+def test_param_order_by(testapp):
+    """Chain processor has to respect 'order_by' parameter."""
+
+    stream = chain.process(
+        testapp,
+        [
+            holocron.Item(
+                {"title": "The Dark Side", "content": "Vader", "id": 3}
+            ),
+            holocron.Item(
+                {"title": "The Force", "content": "Obi-Wan", "id": 1}
+            ),
+            holocron.Item({"title": "Force, The", "content": "Yoda", "id": 2}),
+        ],
+        order_by="id",
+    )
+
+    assert isinstance(stream, collections.abc.Iterable)
+    items = list(stream)
+
+    assert items == [
+        holocron.Item(
+            {
+                "title": "The Force",
+                "content": "Obi-Wan",
+                "next": items[1],
+                "id": 1,
+            }
+        ),
+        holocron.Item(
+            {
+                "title": "Force, The",
+                "content": "Yoda",
+                "prev": items[0],
+                "next": items[2],
+                "id": 2,
+            }
+        ),
+        holocron.Item(
+            {
+                "title": "The Dark Side",
+                "content": "Vader",
+                "prev": items[1],
+                "id": 3,
+            }
+        ),
+    ]
+
+
+def test_param_direction(testapp):
+    """Chain processor has to respect 'direction' parameter."""
+
+    stream = chain.process(
+        testapp,
+        [
+            holocron.Item(
+                {"title": "The Dark Side", "content": "Vader", "id": 3}
+            ),
+            holocron.Item(
+                {"title": "The Force", "content": "Obi-Wan", "id": 1}
+            ),
+            holocron.Item({"title": "Force, The", "content": "Yoda", "id": 2}),
+        ],
+        order_by="id",
+        direction="desc",
+    )
+
+    assert isinstance(stream, collections.abc.Iterable)
+    items = list(stream)
+
+    assert items == [
+        holocron.Item(
+            {
+                "title": "The Dark Side",
+                "content": "Vader",
+                "next": items[1],
+                "id": 3,
+            }
+        ),
+        holocron.Item(
+            {
+                "title": "Force, The",
+                "content": "Yoda",
+                "prev": items[0],
+                "next": items[2],
+                "id": 2,
+            }
+        ),
+        holocron.Item(
+            {
+                "title": "The Force",
+                "content": "Obi-Wan",
+                "prev": items[1],
+                "id": 1,
+            }
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ["params", "error"],
+    [
+        pytest.param(
+            {"order_by": 42},
+            "order_by: 42 is not of type 'string'",
+            id="save_as-int",
+        ),
+        pytest.param(
+            {"order_by": "yoda", "direction": 42},
+            "direction: 42 is not of type 'string'",
+            id="template-int",
+        ),
+        pytest.param(
+            {"order_by": "yoda", "direction": "luke"},
+            "direction: 'luke' is not one of ['asc', 'desc']",
+            id="template-int",
+        ),
+    ],
+)
+def test_param_bad_value(testapp, params, error):
+    """Chain processor has to validate input parameters."""
+
+    with pytest.raises(ValueError) as excinfo:
+        next(chain.process(testapp, [], **params))
+    assert str(excinfo.value) == error


### PR DESCRIPTION
The chain processor is designed to chain items in the input stream by
setting previous and next properties on them. This may be very handy
when you need to render these items with next/previous links on the
page.