### PR TITLE
Move processors arguments under 'args' umbrella

### DIFF
--- a/src/holocron/_core/application.py
+++ b/src/holocron/_core/application.py
@@ -67,13 +67,10 @@ class Application:
         stream = iter(stream or [])
 
         for processor in pipe:
-            processor = processor.copy()
-            processor_name = processor.pop("name")
+            if processor["name"] not in self._processors:
+                raise ValueError(f"no such processor: '{processor['name']}'")
 
-            if processor_name not in self._processors:
-                raise ValueError(f"no such processor: '{processor_name}'")
-
-            processfn = self._processors[processor_name]
+            processfn = self._processors[processor["name"]]
 
             # Resolve every JSON reference we encounter in a processor's
             # parameters. Please note, we're doing this so late because we
@@ -83,6 +80,6 @@ class Application:
                 processor, {"metadata:": self.metadata}
             )
 
-            stream = processfn(self, stream, **processor)
+            stream = processfn(self, stream, **processor.get("args", {}))
 
         yield from stream

--- a/tests/_core/test_application.py
+++ b/tests/_core/test_application.py
@@ -287,7 +287,7 @@ def test_invoke_passthrough_items():
 
 
 @pytest.mark.parametrize(
-    ["processor_options"],
+    ["processor_args"],
     [
         pytest.param({"a": 1}, id="int"),
         pytest.param({"b": 1.13}, id="float"),
@@ -295,23 +295,23 @@ def test_invoke_passthrough_items():
         pytest.param({"a": {"x": [1, 2]}, "b": ["1", 2]}, id="deep-params"),
     ],
 )
-def test_invoke_propagates_processor_options(processor_options):
-    """.invoke() propagates processor's options."""
+def test_invoke_propagates_processor_args(processor_args):
+    """.invoke() propagates processor's arguments."""
 
-    def processor(app, items, **options):
-        assert options == processor_options
+    def processor(app, items, **args):
+        assert args == processor_args
         yield from items
 
     testapp = holocron.Application()
     testapp.add_processor("processor", processor)
-    testapp.add_pipe("test", [dict(processor_options, name="processor")])
+    testapp.add_pipe("test", [{"name": "processor", "args": processor_args}])
 
     with pytest.raises(StopIteration):
         next(testapp.invoke("test"))
 
 
 @pytest.mark.parametrize(
-    ["options", "resolved"],
+    ["processor_args", "resolved"],
     [
         pytest.param(
             {"a": {"$ref": "metadata://#/is_yoda_master"}},
@@ -338,19 +338,19 @@ def test_invoke_propagates_processor_options(processor_options):
         ),
     ],
 )
-def test_invoke_resolves_jsonref(options, resolved):
-    """.invoke() resolves JSON references in processor's options."""
+def test_invoke_resolves_jsonref(processor_args, resolved):
+    """.invoke() resolves JSON references in processor's arguments."""
 
     testapp = holocron.Application(
         {"extra": [{"luke": "skywalker"}], "is_yoda_master": True}
     )
 
-    def processor(app, items, **options):
-        assert options == resolved
+    def processor(app, items, **args):
+        assert args == resolved
         yield from items
 
     testapp.add_processor("processor", processor)
-    testapp.add_pipe("test", [dict(options, name="processor")])
+    testapp.add_pipe("test", [{"name": "processor", "args": processor_args}])
 
     with pytest.raises(StopIteration):
         next(testapp.invoke("test"))

--- a/tests/_processors/test_archive.py
+++ b/tests/_processors/test_archive.py
@@ -50,7 +50,7 @@ def test_item(testapp):
     ],
 )
 def test_item_many(testapp, amount):
-    """archive processor has to work with stream."""
+    """Archive processor has to work with stream."""
 
     stream = archive.process(
         testapp,
@@ -87,8 +87,8 @@ def test_item_many(testapp, amount):
     )
 
 
-def test_param_template(testapp):
-    """archive processor has respect template parameter."""
+def test_args_template(testapp):
+    """Archive processor has respect 'template' argument."""
 
     stream = archive.process(
         testapp,
@@ -120,8 +120,8 @@ def test_param_template(testapp):
         pytest.param(pathlib.Path("yoda.jedi"), id="flat"),
     ],
 )
-def test_param_save_as(testapp, save_as):
-    """archive processor has to respect save_as parameter."""
+def test_args_save_as(testapp, save_as):
+    """Archive processor has to respect 'save_as' argument."""
 
     stream = archive.process(
         testapp,
@@ -147,7 +147,7 @@ def test_param_save_as(testapp, save_as):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"save_as": 42},
@@ -181,9 +181,9 @@ def test_param_save_as(testapp, save_as):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """archive processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Archive processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(archive.process(testapp, [], **params))
+        next(archive.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_chain.py
+++ b/tests/_processors/test_chain.py
@@ -83,8 +83,8 @@ def test_three_items(testapp):
     ]
 
 
-def test_param_order_by(testapp):
-    """Chain processor has to respect 'order_by' parameter."""
+def test_args_order_by(testapp):
+    """Chain processor has to respect 'order_by' argument."""
 
     stream = chain.process(
         testapp,
@@ -132,8 +132,8 @@ def test_param_order_by(testapp):
     ]
 
 
-def test_param_direction(testapp):
-    """Chain processor has to respect 'direction' parameter."""
+def test_args_direction(testapp):
+    """Chain processor has to respect 'direction' argument."""
 
     stream = chain.process(
         testapp,
@@ -183,7 +183,7 @@ def test_param_direction(testapp):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"order_by": 42},
@@ -202,9 +202,9 @@ def test_param_direction(testapp):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Chain processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Chain processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(chain.process(testapp, [], **params))
+        next(chain.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_commonmark.py
+++ b/tests/_processors/test_commonmark.py
@@ -317,7 +317,7 @@ def test_item_many(testapp, amount):
         ),
     ],
 )
-def test_param_pygmentize(testapp, rendered, pygmentize):
+def test_args_pygmentize(testapp, rendered, pygmentize):
     """Commonmark processor has to pygmentize code with language."""
 
     stream = commonmark.process(
@@ -355,7 +355,7 @@ def test_param_pygmentize(testapp, rendered, pygmentize):
 @pytest.mark.parametrize(
     ["language"], [pytest.param("yoda"), pytest.param("vader")]
 )
-def test_param_pygmentize_unknown_language(testapp, language):
+def test_args_pygmentize_unknown_language(testapp, language):
     """Commonmark has to assume text/plain for unknown languages."""
 
     stream = commonmark.process(
@@ -395,7 +395,7 @@ def test_param_pygmentize_unknown_language(testapp, language):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"pygmentize": 42},
@@ -404,9 +404,9 @@ def test_param_pygmentize_unknown_language(testapp, language):
         )
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Commonmark processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Commonmark processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(commonmark.process(testapp, [], **params))
+        next(commonmark.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_feed.py
+++ b/tests/_processors/test_feed.py
@@ -535,8 +535,8 @@ def test_item_many(testapp, syndication_format, amount):
 @pytest.mark.parametrize(
     ["encoding"], [pytest.param("CP1251"), pytest.param("UTF-16")]
 )
-def test_param_encoding(testapp, syndication_format, encoding):
-    """Feed processor has to respect encoding parameter."""
+def test_args_encoding(testapp, syndication_format, encoding):
+    """Feed processor has to respect encoding argument."""
 
     published = datetime.datetime(2017, 9, 25, tzinfo=datetime.timezone.utc)
     stream = feed.process(
@@ -585,8 +585,8 @@ def test_param_encoding(testapp, syndication_format, encoding):
 @pytest.mark.parametrize(
     ["encoding"], [pytest.param("CP1251"), pytest.param("UTF-16")]
 )
-def test_param_encoding_fallback(testapp, syndication_format, encoding):
-    """Feed processor has to respect encoding parameter (fallback)."""
+def test_args_encoding_fallback(testapp, syndication_format, encoding):
+    """Feed processor has to respect encoding argument (fallback)."""
 
     testapp.metadata.update({"encoding": encoding})
 
@@ -640,8 +640,8 @@ def test_param_encoding_fallback(testapp, syndication_format, encoding):
         pytest.param(pathlib.Path("foo", "bar.xml")),
     ],
 )
-def test_param_save_as(testapp, syndication_format, save_as):
-    """Feed processor has to respect save_as parameter."""
+def test_args_save_as(testapp, syndication_format, save_as):
+    """Feed processor has to respect save_as argument."""
 
     stream = feed.process(
         testapp,
@@ -691,8 +691,8 @@ def test_param_save_as(testapp, syndication_format, save_as):
     ["syndication_format"], [pytest.param("atom"), pytest.param("rss")]
 )
 @pytest.mark.parametrize(["limit"], [pytest.param(2), pytest.param(5)])
-def test_param_limit(testapp, syndication_format, limit):
-    """Feed processor has to respect limit parameter."""
+def test_args_limit(testapp, syndication_format, limit):
+    """Feed processor has to respect limit argument."""
 
     stream = feed.process(
         testapp,
@@ -775,8 +775,8 @@ def test_param_limit(testapp, syndication_format, limit):
         pytest.param(True, lambda x: x > 10, id="yes"),
     ],
 )
-def test_param_pretty(testapp, syndication_format, pretty, check_fn):
-    """Feed processor has to respect pretty parameter."""
+def test_args_pretty(testapp, syndication_format, pretty, check_fn):
+    """Feed processor has to respect pretty argument."""
 
     stream = feed.process(
         testapp,
@@ -825,7 +825,7 @@ def test_param_pretty(testapp, syndication_format, pretty, check_fn):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"encoding": "UTF-42"},
@@ -849,9 +849,9 @@ def test_param_pretty(testapp, syndication_format, pretty, check_fn):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Feed processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Feed processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(feed.process(testapp, [], **params))
+        next(feed.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_frontmatter.py
+++ b/tests/_processors/test_frontmatter.py
@@ -325,8 +325,8 @@ def test_item_many(testapp, amount):
 @pytest.mark.parametrize(
     ["delimiter"], [pytest.param("+++"), pytest.param("***")]
 )
-def test_param_delimiter(testapp, delimiter):
-    """Frontmatter processor has to respect 'delimiter' parameter."""
+def test_args_delimiter(testapp, delimiter):
+    """Frontmatter processor has to respect 'delimiter' argument."""
 
     stream = frontmatter.process(
         testapp,
@@ -366,8 +366,8 @@ def test_param_delimiter(testapp, delimiter):
 @pytest.mark.parametrize(
     ["overwrite"], [pytest.param(False), pytest.param(True)]
 )
-def test_param_overwrite(testapp, overwrite):
-    """Frontmatter processor has to respect 'overwrite' parameter."""
+def test_args_overwrite(testapp, overwrite):
+    """Frontmatter processor has to respect 'overwrite' argument."""
 
     stream = frontmatter.process(
         testapp,
@@ -470,8 +470,8 @@ def test_param_overwrite(testapp, overwrite):
         ),
     ],
 )
-def test_param_format(testapp, frontsnippet, format, exception):
-    """Frontmatter has to respect 'format' parameter."""
+def test_args_format(testapp, frontsnippet, format, exception):
+    """Frontmatter has to respect 'format' argument."""
 
     stream = frontmatter.process(
         testapp,
@@ -516,7 +516,7 @@ def test_param_format(testapp, frontsnippet, format, exception):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"delimiter": 42},
@@ -530,9 +530,9 @@ def test_param_format(testapp, frontsnippet, format, exception):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Frontmatter processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Frontmatter processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(frontmatter.process(testapp, [], **params))
+        next(frontmatter.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_jinja2.py
+++ b/tests/_processors/test_jinja2.py
@@ -153,8 +153,8 @@ def test_item_many(testapp, tmpdir, amount):
     assert len(static) == 3
 
 
-def test_param_themes(testapp, tmpdir):
-    """Jinja2 processor has to respect themes parameter."""
+def test_args_themes(testapp, tmpdir):
+    """Jinja2 processor has to respect themes argument."""
 
     tmpdir.ensure("theme_a", "templates", "item.j2").write_text(
         textwrap.dedent(
@@ -205,8 +205,8 @@ def test_param_themes(testapp, tmpdir):
     ]
 
 
-def test_param_themes_two_themes(testapp, tmpdir):
-    """Jinja2 processor has to respect themes parameter."""
+def test_args_themes_two_themes(testapp, tmpdir):
+    """Jinja2 processor has to respect themes argument."""
 
     tmpdir.ensure("theme_a", "templates", "page.j2").write_text(
         textwrap.dedent(
@@ -290,7 +290,7 @@ def test_param_themes_two_themes(testapp, tmpdir):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"template": 42},
@@ -309,9 +309,9 @@ def test_param_themes_two_themes(testapp, tmpdir):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Commit processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Commit processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(jinja2.process(testapp, [], **params))
+        next(jinja2.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_markdown.py
+++ b/tests/_processors/test_markdown.py
@@ -500,8 +500,8 @@ def test_item_many(testapp, amount):
         ),
     ],
 )
-def test_param_extensions(testapp, extensions, rendered):
-    """Markdown processor has to respect extensions parameter."""
+def test_args_extensions(testapp, extensions, rendered):
+    """Markdown processor has to respect extensions argument."""
 
     stream = markdown.process(
         testapp,
@@ -535,7 +535,7 @@ def test_param_extensions(testapp, extensions, rendered):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"extensions": 42},
@@ -549,9 +549,9 @@ def test_param_extensions(testapp, extensions, rendered):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Markdown processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Markdown processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(markdown.process(testapp, [], **params))
+        next(markdown.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_metadata.py
+++ b/tests/_processors/test_metadata.py
@@ -86,8 +86,8 @@ def test_item_many(testapp, amount):
         pytest.param(False, "skywalker", id="not-overwrite"),
     ],
 )
-def test_param_overwrite(testapp, overwrite, author):
-    """Metadata processor has to respect overwrite option."""
+def test_args_overwrite(testapp, overwrite, author):
+    """Metadata processor has to respect 'overwrite' argument."""
 
     stream = metadata.process(
         testapp,
@@ -105,7 +105,7 @@ def test_param_overwrite(testapp, overwrite, author):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"metadata": 42},
@@ -119,9 +119,9 @@ def test_param_overwrite(testapp, overwrite, author):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Metadata processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Metadata processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(metadata.process(testapp, [], **params))
+        next(metadata.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_pipe.py
+++ b/tests/_processors/test_pipe.py
@@ -10,17 +10,17 @@ from holocron._processors import pipe
 
 @pytest.fixture(scope="function")
 def testapp():
-    def spam(app, items, **options):
+    def spam(app, items, **args):
         for item in items:
-            item["spam"] = options.get("text", 42)
+            item["spam"] = args.get("text", 42)
             yield item
 
-    def eggs(app, items, **options):
+    def eggs(app, items, **args):
         for item in items:
             item["content"] += " #friedeggs"
             yield item
 
-    def rice(app, items, **options):
+    def rice(app, items, **args):
         yield from items
         yield holocron.Item({"content": "rice"})
 
@@ -53,13 +53,13 @@ def test_item(testapp):
     ]
 
 
-def test_item_processor_with_option(testapp):
-    """Pipe processor has to pass down processors options."""
+def test_item_processor_with_args(testapp):
+    """Pipe processor has to pass down processors arguments."""
 
     stream = pipe.process(
         testapp,
         [holocron.Item({"content": "the Force", "author": "skywalker"})],
-        pipe=[{"name": "spam", "text": 1}],
+        pipe=[{"name": "spam", "args": {"text": 1}}],
     )
 
     assert isinstance(stream, collections.abc.Iterable)
@@ -70,7 +70,7 @@ def test_item_processor_with_option(testapp):
     ]
 
 
-def test_param_pipeline_empty(testapp):
+def test_args_pipeline_empty(testapp):
     """Pipe processor with empty pipeline has to pass by."""
 
     stream = pipe.process(
@@ -123,16 +123,16 @@ def test_item_many(testapp, amount):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"pipe": 42}, "pipe: 42 is not of type 'array'", id="pipe-int"
         )
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Pipe processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Pipe processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(pipe.process(testapp, [], **params))
+        next(pipe.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_restructuredtext.py
+++ b/tests/_processors/test_restructuredtext.py
@@ -270,7 +270,7 @@ def test_item_with_inline_code(testapp):
     ]
 
 
-def test_param_settings(testapp):
+def test_args_settings(testapp):
     """reStructuredText processor has to respect custom settings."""
 
     stream = restructuredtext.process(
@@ -355,7 +355,7 @@ def test_item_many(testapp, amount):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"settings": 42},
@@ -364,9 +364,9 @@ def test_item_many(testapp, amount):
         )
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """reStructuredText processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """reStructuredText processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(restructuredtext.process(testapp, [], **params))
+        next(restructuredtext.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_save.py
+++ b/tests/_processors/test_save.py
@@ -132,8 +132,8 @@ def test_item_many(testapp, monkeypatch, tmpdir, amount):
 @pytest.mark.parametrize(
     ["encoding"], [pytest.param("CP1251"), pytest.param("UTF-16")]
 )
-def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
-    """Save processor has to respect 'encoding' parameter."""
+def test_args_encoding(testapp, monkeypatch, tmpdir, encoding):
+    """Save processor has to respect 'encoding' argument."""
 
     monkeypatch.chdir(tmpdir)
 
@@ -159,8 +159,8 @@ def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
 @pytest.mark.parametrize(
     ["encoding"], [pytest.param("CP1251"), pytest.param("UTF-16")]
 )
-def test_param_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
-    """Save processor has to respect 'encoding' parameter (fallback)."""
+def test_args_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
+    """Save processor has to respect 'encoding' argument (fallback)."""
 
     monkeypatch.chdir(tmpdir)
     testapp.metadata.update({"encoding": encoding})
@@ -186,8 +186,8 @@ def test_param_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
 @pytest.mark.parametrize(
     ["to"], [pytest.param("_build"), pytest.param("_public")]
 )
-def test_param_to(testapp, monkeypatch, tmpdir, to):
-    """Save processor has to respect 'to' parameter."""
+def test_args_to(testapp, monkeypatch, tmpdir, to):
+    """Save processor has to respect 'to' argument."""
 
     monkeypatch.chdir(tmpdir)
 
@@ -211,7 +211,7 @@ def test_param_to(testapp, monkeypatch, tmpdir, to):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"to": 42}, "to: 42 is not of type 'string'", id="to-int"
@@ -241,9 +241,9 @@ def test_param_to(testapp, monkeypatch, tmpdir, to):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Save processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Save processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(save.process(testapp, [], **params))
+        next(save.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_sitemap.py
+++ b/tests/_processors/test_sitemap.py
@@ -183,8 +183,8 @@ def test_item_many_zero(testapp):
     ]
 
 
-def test_param_gzip(testapp):
-    """Sitemap processor has to respect gzip parameter."""
+def test_args_gzip(testapp):
+    """Sitemap processor has to respect gzip argument."""
 
     timepoint = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     stream = sitemap.process(
@@ -239,8 +239,8 @@ def test_param_gzip(testapp):
         pytest.param(pathlib.Path("yoda.jedi"), id="flat"),
     ],
 )
-def test_param_save_as(testapp, save_as):
-    """Sitemap processor has to respect save_as parameter."""
+def test_args_save_as(testapp, save_as):
+    """Sitemap processor has to respect save_as argument."""
 
     timepoint = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     stream = sitemap.process(
@@ -292,7 +292,7 @@ def test_param_save_as(testapp, save_as):
         ),
     ],
 )
-def test_param_save_as_unsupported(testapp, document_path, sitemap_path):
+def test_args_save_as_unsupported(testapp, document_path, sitemap_path):
     """Sitemap process has to check enlisted URLs for compatibility."""
 
     timepoint = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
@@ -326,8 +326,8 @@ def test_param_save_as_unsupported(testapp, document_path, sitemap_path):
 @pytest.mark.parametrize(
     ["pretty", "lines"], [pytest.param(False, 1), pytest.param(True, 7)]
 )
-def test_param_pretty(testapp, pretty, lines):
-    """Sitemap processor has to respect pretty parameter."""
+def test_args_pretty(testapp, pretty, lines):
+    """Sitemap processor has to respect pretty argument."""
 
     timepoint = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
     stream = sitemap.process(
@@ -368,7 +368,7 @@ def test_param_pretty(testapp, pretty, lines):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"gzip": "true"},
@@ -387,9 +387,9 @@ def test_param_pretty(testapp, pretty, lines):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Sitemap processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Sitemap processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(sitemap.process(testapp, [], **params))
+        next(sitemap.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_source.py
+++ b/tests/_processors/test_source.py
@@ -193,8 +193,8 @@ def test_item_many(testapp, monkeypatch, tmpdir, discovered, passed):
         pytest.param(["a", "b", "c"]),
     ],
 )
-def test_param_path(testapp, monkeypatch, tmpdir, path):
-    """Source processor has to respect path parameter."""
+def test_args_path(testapp, monkeypatch, tmpdir, path):
+    """Source processor has to respect path argument."""
 
     monkeypatch.chdir(tmpdir)
     tmpdir.join(*path).ensure("test").write_text("Obi-Wan", encoding="UTF-8")
@@ -220,8 +220,8 @@ def test_param_path(testapp, monkeypatch, tmpdir, path):
     ]
 
 
-def test_param_pattern(testapp, monkeypatch, tmpdir):
-    """Source processor has to respect pattern parameter."""
+def test_args_pattern(testapp, monkeypatch, tmpdir):
+    """Source processor has to respect pattern argument."""
 
     monkeypatch.chdir(tmpdir)
 
@@ -266,8 +266,8 @@ def test_param_pattern(testapp, monkeypatch, tmpdir):
 @pytest.mark.parametrize(
     ["encoding"], [pytest.param("CP1251"), pytest.param("UTF-16")]
 )
-def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
-    """Source processor has to respect encoding parameter."""
+def test_args_encoding(testapp, monkeypatch, tmpdir, encoding):
+    """Source processor has to respect encoding argument."""
 
     monkeypatch.chdir(tmpdir)
     tmpdir.ensure("cv.md").write_text("Оби-Ван", encoding=encoding)
@@ -292,8 +292,8 @@ def test_param_encoding(testapp, monkeypatch, tmpdir, encoding):
 @pytest.mark.parametrize(
     ["encoding"], [pytest.param("CP1251"), pytest.param("UTF-16")]
 )
-def test_param_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
-    """Source processor has to respect encoding parameter (fallback)."""
+def test_args_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
+    """Source processor has to respect encoding argument (fallback)."""
 
     monkeypatch.chdir(tmpdir)
     tmpdir.ensure("cv.md").write_text("Оби-Ван", encoding=encoding)
@@ -323,8 +323,8 @@ def test_param_encoding_fallback(testapp, monkeypatch, tmpdir, encoding):
         pytest.param("Europe/Kiev", ["EET", "EEST"]),
     ],
 )
-def test_param_timezone(testapp, monkeypatch, tmpdir, timezone, tznames):
-    """Source processor has to respect timezone parameter."""
+def test_args_timezone(testapp, monkeypatch, tmpdir, timezone, tznames):
+    """Source processor has to respect timezone argument."""
 
     monkeypatch.chdir(tmpdir)
     tmpdir.ensure("cv.md").write_text("Obi-Wan", encoding="UTF-8")
@@ -349,8 +349,8 @@ def test_param_timezone(testapp, monkeypatch, tmpdir, timezone, tznames):
         pytest.param("Europe/Kiev", ["EET", "EEST"]),
     ],
 )
-def test_param_timezone_fallback(testapp, monkeypatch, tmpdir, tz, tznames):
-    """Source processor has to respect timezone parameter (fallback)."""
+def test_args_timezone_fallback(testapp, monkeypatch, tmpdir, tz, tznames):
+    """Source processor has to respect timezone argument (fallback)."""
 
     monkeypatch.chdir(tmpdir)
     tmpdir.ensure("cv.md").write_text("Obi-Wan", encoding="UTF-8")
@@ -369,8 +369,8 @@ def test_param_timezone_fallback(testapp, monkeypatch, tmpdir, tz, tznames):
     assert updated.tzinfo.tzname(updated) in tznames
 
 
-def test_param_timezone_in_action(testapp, monkeypatch, tmpdir):
-    """Source processor has to respect timezone parameter."""
+def test_args_timezone_in_action(testapp, monkeypatch, tmpdir):
+    """Source processor has to respect timezone argument."""
 
     monkeypatch.chdir(tmpdir)
     tmpdir.ensure("cv.md").write_text("Obi-Wan", encoding="UTF-8")
@@ -398,7 +398,7 @@ def test_param_timezone_in_action(testapp, monkeypatch, tmpdir):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"path": 42}, "path: 42 is not of type 'string'", id="path-int"
@@ -420,9 +420,9 @@ def test_param_timezone_in_action(testapp, monkeypatch, tmpdir):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Source processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Source processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(source.process(testapp, [], **params))
+        next(source.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_todatetime.py
+++ b/tests/_processors/test_todatetime.py
@@ -212,8 +212,8 @@ def test_item_timestamp_bad_value(testapp):
         pytest.param(pathlib.Path("2019-01-11"), id="path"),
     ],
 )
-def test_param_todatetime(testapp, timestamp):
-    """Todatetime processor has to respect "writeto" parameter."""
+def test_args_todatetime(testapp, timestamp):
+    """Todatetime processor has to respect "writeto" argument."""
 
     stream = todatetime.process(
         testapp,
@@ -259,8 +259,8 @@ def test_param_todatetime(testapp, timestamp):
         ),
     ],
 )
-def test_param_parsearea(testapp, timestamp, parsearea):
-    """Todatetime processor has to respect "parsearea" parameter."""
+def test_args_parsearea(testapp, timestamp, parsearea):
+    """Todatetime processor has to respect "parsearea" argument."""
 
     stream = todatetime.process(
         testapp,
@@ -288,8 +288,8 @@ def test_param_parsearea(testapp, timestamp, parsearea):
     ]
 
 
-def test_param_parsearea_not_found(testapp):
-    """Todatetime processor has to respect "parsearea" parameter."""
+def test_args_parsearea_not_found(testapp):
+    """Todatetime processor has to respect "parsearea" argument."""
 
     stream = todatetime.process(
         testapp,
@@ -331,8 +331,8 @@ def test_param_parsearea_not_found(testapp):
         pytest.param("http://example.com/posts/2019-01-11-luke-skywalker.txt"),
     ],
 )
-def test_param_fuzzy(testapp, timestamp):
-    """Todatetime processor has to respect "fuzzy" parameter."""
+def test_args_fuzzy(testapp, timestamp):
+    """Todatetime processor has to respect "fuzzy" argument."""
 
     stream = todatetime.process(
         testapp,
@@ -360,8 +360,8 @@ def test_param_fuzzy(testapp, timestamp):
 
 
 @pytest.mark.parametrize(["tz"], [pytest.param("EET"), pytest.param("UTC")])
-def test_param_timezone(testapp, tz):
-    """Todatetime processor has to respect "timezone" parameter."""
+def test_args_timezone(testapp, tz):
+    """Todatetime processor has to respect "timezone" argument."""
 
     stream = todatetime.process(
         testapp,
@@ -381,7 +381,7 @@ def test_param_timezone(testapp, tz):
         ],
         todatetime="timestamp",
         # Custom timezone has to be attached only to timestamps without
-        # explicit timezone information. So this option is nothing more
+        # explicit timezone information. So this argument is nothing more
         # but a fallback.
         timezone=tz,
     )
@@ -408,8 +408,8 @@ def test_param_timezone(testapp, tz):
 
 
 @pytest.mark.parametrize(["tz"], [pytest.param("EET"), pytest.param("UTC")])
-def test_param_timezone_fallback(testapp, tz):
-    """Todatetime processor has to respect "timezone" parameter (fallback)."""
+def test_args_timezone_fallback(testapp, tz):
+    """Todatetime processor has to respect "timezone" argument (fallback)."""
 
     # Custom timezone has to be attached only to timestamps without
     # explicit timezone information. So this option is nothing more
@@ -457,7 +457,7 @@ def test_param_timezone_fallback(testapp, tz):
 
 
 @pytest.mark.parametrize(
-    ["params", "error"],
+    ["args", "error"],
     [
         pytest.param(
             {"todatetime": 42},
@@ -479,9 +479,9 @@ def test_param_timezone_fallback(testapp, tz):
         ),
     ],
 )
-def test_param_bad_value(testapp, params, error):
-    """Todatetime processor has to validate input parameters."""
+def test_args_bad_value(testapp, args, error):
+    """Todatetime processor has to validate input arguments."""
 
     with pytest.raises(ValueError) as excinfo:
-        next(todatetime.process(testapp, [], **params))
+        next(todatetime.process(testapp, [], **args))
     assert str(excinfo.value) == error

--- a/tests/_processors/test_when.py
+++ b/tests/_processors/test_when.py
@@ -169,7 +169,7 @@ def test_item_many_eggs(testapp):
         pytest.param([r"item.source | match('^about.*')"], id="match-about"),
     ],
 )
-def test_param_when(testapp, cond):
+def test_args_when(testapp, cond):
     """When processor has to respect conditions."""
 
     stream = when.process(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -164,7 +164,9 @@ def test_run_conf_yml_interpolate(monkeypatch, tmpdir, execute):
                         {"name": "source"},
                         {
                             "name": "metadata",
-                            "metadata": {"content": "%(here)s/secret"},
+                            "args": {
+                                "metadata": {"content": "%(here)s/secret"},
+                            },
                         },
                         {"name": "save"},
                     ]
@@ -195,8 +197,8 @@ def test_run_conf_yml_interpolate_in_path(
                 "metadata": {"url": "https://yoda.ua"},
                 "pipes": {
                     "test": [
-                        {"name": "source", "path": "%(here)s"},
-                        {"name": "save", "to": "%(here)s/_compiled"},
+                        {"name": "source", "args": {"path": "%(here)s"}},
+                        {"name": "save", "args": {"to": "%(here)s/_compiled"}},
                     ]
                 },
             },


### PR DESCRIPTION
Processors arguments are used to be defined top-level in the pipeline,
alongside with the processor name. This effectively means that every
processor definition in the pipeline has its own schema.

Well, I don't want to see that and I'd prefer to ensure that the schema
is consistent across definitions. One way to achieve this is to move
every processor argument under 'args' umbrella. This is exactly what
this commit is responsible for.