### PR TITLE
Add notion of processor wrappers

### DIFF
--- a/src/holocron/_core/factories.py
+++ b/src/holocron/_core/factories.py
@@ -1,7 +1,7 @@
 """Factory functions to create core instances."""
 
 from . import Application
-from .._processors import import_processors
+from .._processors import import_processors, when
 
 
 def create_app(metadata, processors=None, pipes=None):
@@ -34,9 +34,14 @@ def create_app(metadata, processors=None, pipes=None):
             "sitemap = holocron._processors.sitemap:process",
             "source = holocron._processors.source:process",
             "todatetime = holocron._processors.todatetime:process",
-            "when = holocron._processors.when:process",
         ],
     )
+
+    # When is the only known processor wrapper, and, frankly, we don't expect
+    # more. Processor wrappers are mere hacks to avoid hardcoding yet provide
+    # better syntax for wrapping processors. So let's hardcode that knowledge
+    # here, and think later about general approach when the need arise.
+    instance.add_processor_wrapper("when", when.process)
 
     for name, processor in (processors or {}).items():
         instance.add_processor(name, processor)

--- a/tests/_core/test_factories.py
+++ b/tests/_core/test_factories.py
@@ -29,6 +29,7 @@ def test_create_app_processors_discover():
         "todatetime",
         "when",
     }
+    assert set(testapp._processor_wrappers) == {"when"}
 
 
 def test_create_app_processors_pass(caplog):


### PR DESCRIPTION
Processor wrappers are special kind of processors which receive another
processor as input argument and are fully responsible for invoking it.
In fact, they are just like any other processor except for syntax sugar
provided by Holocron that helps to invoke them easier and avoiding
nesting structures in pipeline definition.