### PR TITLE
commonmark: wrap code inside `<pre>` into `<code>`

### DIFF
--- a/src/holocron/_processors/commonmark.py
+++ b/src/holocron/_processors/commonmark.py
@@ -18,7 +18,8 @@ def _pygmentize(code, language):
     try:
         formatter = _pygmentize.formatter
     except AttributeError:
-        formatter = _pygmentize.formatter = pygments.formatters.html.HtmlFormatter()
+        HtmlFormatter = pygments.formatters.html.HtmlFormatter
+        formatter = _pygmentize.formatter = HtmlFormatter(wrapcode=True)
 
     lexer = pygments.lexers.get_lexer_by_name(language)
     return pygments.highlight(code, lexer, formatter)

--- a/tests/_processors/test_commonmark.py
+++ b/tests/_processors/test_commonmark.py
@@ -307,7 +307,13 @@ def test_item_many(testapp, amount):
             id="pygmentize=off",
         ),
         pytest.param(
-            r"<p>test codeblock</p>\s*.*highlight.*<pre>[\s\S]+</pre>.*",
+            (
+                r"<p>test codeblock</p>\s*"
+                r".*highlight.*"
+                r"<pre>\s*<span>\s*</span>\s*"
+                r"<code>[\s\S]+</code>\s*"
+                r"</pre>.*"
+            ),
             True,
             id="pygmentize=on",
         ),


### PR DESCRIPTION
Wrap the code inside `<pre>` blocks using `<code>`, as recommended by
the HTML5 specification.