### PR TITLE
Bunch of changes in project infrastracture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "holocron"
 version = "0.4.0"
@@ -51,7 +55,3 @@ untangle = "^1.1"
 
 [tool.poetry.scripts]
 holocron = "holocron.__main__:main"
-
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,27 @@
 [tox]
+minversion = 3.3.0
+isolated_build = true
 envlist = py3, pre-commit, docs
 
 [testenv]
-deps = poetry
-skip_install = true
+deps =
+    poetry
 commands =
-    poetry install -v
-    poetry run coverage run -m pytest
-    poetry run coverage combine
-    poetry run coverage report -m
+    # Because poetry does not support installing `dev-dependencies` from
+    # sdist, we have to install them using poetry.
+    poetry install -vv --no-root
+    poetry run pytest {posargs}
 
 [testenv:pre-commit]
-skip_install = true
-deps = pre-commit
+deps =
+    pre-commit
 commands =
-    pre-commit run --all-files --show-diff-on-failure
+    {envpython} -m pre_commit run --all-files --show-diff-on-failure
+skip_install = true
 
 [testenv:docs]
 deps =
     Sphinx
     sphinx_rtd_theme
-    poetry
 commands =
-    poetry install -v
     sphinx-build -b html -d {envtmpdir}/doctrees docs docs/_build/


### PR DESCRIPTION
* Updated `[build-system]` in `pyproject.toml` to use modern version of
  poetry bootstrap.

* Removed coverage integration from `tox.ini`.

* Use PEP-517 and PEP-518 installation methods in tox.