### PR TITLE
Use actions/setup-python instead of actions/cache

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,18 +6,17 @@ on:
       - '[1-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  release:
+  pypi:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up cache
-        uses: actions/cache@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-pip-
+          cache: pip
+          cache-dependency-path: poetry.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up cache
-        uses: actions/cache@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('poetry.lock') }}
-          restore-keys: ${{ runner.os }}-pip-
+          cache: pip
+          cache-dependency-path: poetry.lock
 
       - name: Install dependencies
         run: |
@@ -34,26 +33,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: poetry.lock
 
-    - name: Set up cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('poetry.lock') }}
-        restore-keys: ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade tox
-
-    - name: Run tests
-      run: |
-        python -m tox -e py3
+      - name: Run tests
+        run: |
+          python -m tox -e py3


### PR DESCRIPTION
The former integrates the latter. There at least two reasons why using
actions/setup-python is preferable over actions/cache:

* Caching pip wheels is OS dependent. Since `actions/cache` is
  language/tool agnostic, in order to support multiple OSes multiple
  steps are required (per OS).

* Using setup-python better communicates that the workflow requires and
  depends on python.