### PR TITLE
Add 'dot' rendering to commonmark processor

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,15 +14,14 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Install dependencies
-        run: |
-          pipx install hatch
+        run: pipx install hatch
 
       - name: Build
-        run: |
-          hatch build
+        run: hatch build
 
       - name: Publish to PyPI
-        run: |
-          hatch publish --user __token__ --auth ${{ secrets.PYPI_TOKEN }}
+        run: hatch publish --user __token__ --auth ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
       - name: Run pre-commit
-        run: |
-          pipx run -- hatch run lint:run
+        run: pipx run -- hatch run lint:run
 
   test:
     runs-on: ubuntu-latest
@@ -31,6 +32,8 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Set up prerequisites
+        run: sudo apt-get install graphviz libgraphviz-dev
+
       - name: Run tests
-        run: |
-          pipx run -- hatch run test:run
+        run: pipx run -- hatch run test:run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "Markdown >= 3.4",
     "docutils >= 0.19",
     "feedgen >= 0.9",
+    "pygraphviz >= 1.10",
     "termcolor >= 1.1",
     "colorama >= 0.4",
     "markdown-it-py >= 2.1",


### PR DESCRIPTION
DOT language has been developed and primarly consumed by graphviz to render diagrams from text. This patch adds a DOT diagram rendering from the fenced code block into SVG and inserting that SVG picture into the document instead.