### PR TITLE
Use general approach for rendering in commonmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,5 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Set up prerequisites
-        run: sudo apt-get install graphviz libgraphviz-dev
-
       - name: Test
         run: pipx run -- hatch run test:run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "Markdown >= 3.4",
     "docutils >= 0.19",
     "feedgen >= 0.9",
-    "pygraphviz >= 1.10",
     "termcolor >= 1.1",
     "colorama >= 0.4",
     "markdown-it-py >= 2.1",
@@ -77,10 +76,10 @@ scripts.fmt = ["ruff --fix {args:.}", "black {args:.}"]
 
 [tool.ruff]
 select = ["F", "E", "W", "I", "S", "FBT", "B", "C4", "DTZ", "T10", "ISC", "RET", "SLF", "RUF"]
-ignore = ["S701", "B904"]
+ignore = ["S603", "S701", "B904"]
 
 [tool.ruff.isort]
 known-first-party = ["holocron"]
 
 [tool.ruff.per-file-ignores]
-"tests/*" = ["E501", "S101", "S603", "S607", "SLF001", "RUF001"]
+"tests/*" = ["E501", "S101", "S607", "SLF001", "RUF001"]

--- a/tests/_processors/test_commonmark.py
+++ b/tests/_processors/test_commonmark.py
@@ -407,7 +407,7 @@ def test_args_pygmentize_unknown_language(testapp, language):
     ]
 
 
-def test_item_dot_render(testapp):
+def test_item_exec(testapp):
     """Commonmark has to render DOT snippets into SVG if asked to render."""
 
     stream = commonmark.process(
@@ -417,10 +417,8 @@ def test_item_dot_render(testapp):
                 {
                     "content": textwrap.dedent(
                         """
-                        ```dot {"format": "svg"}
-                        graph yoda {
-                            a -- b -- c
-                        }
+                        ```text {"exec": ["sed", "--expression", "s/ a / the /g"]}
+                        yoda, a jedi grandmaster
                         ```
                         """
                     ),
@@ -435,57 +433,11 @@ def test_item_dot_render(testapp):
     assert list(stream) == [
         holocron.Item(
             {
-                "content": '<p><img src="diagram-0.svg" alt="" /></p>\n',
+                "content": "yoda, the jedi grandmaster\n",
                 "source": pathlib.Path("1.md"),
                 "destination": pathlib.Path("1.html"),
             },
         ),
-        holocron.WebSiteItem(
-            {
-                "content": _pytest_regex(rb".*</svg>\s*", re.DOTALL | re.MULTILINE),
-                "source": pathlib.Path("dot://1.md/diagram-0.svg"),
-                "destination": pathlib.Path("diagram-0.svg"),
-                "baseurl": "https://yoda.ua",
-            }
-        ),
-    ]
-
-
-def test_item_dot_not_rendered(testapp):
-    """Commonmark has to preserve DOT snippet if not asked to render."""
-
-    stream = commonmark.process(
-        testapp,
-        [
-            holocron.Item(
-                {
-                    "content": textwrap.dedent(
-                        """
-                        ```dot
-                        graph yoda {
-                            a -- b -- c
-                        }
-                        ```
-                        """
-                    ),
-                    "destination": pathlib.Path("1.md"),
-                }
-            )
-        ],
-    )
-
-    assert isinstance(stream, collections.abc.Iterable)
-    assert list(stream) == [
-        holocron.Item(
-            {
-                "content": (
-                    '<pre><code class="language-dot">graph yoda {\n'
-                    "    a -- b -- c\n"
-                    "}\n</code></pre>\n"
-                ),
-                "destination": pathlib.Path("1.html"),
-            }
-        )
     ]
 
 


### PR DESCRIPTION
Instead of supporting graphviz and any other possible text-to-diagram providers directly, let's build a general approach instead where a user can specify whatever executable they want to pipe the content of the code block through it, and replace the whole node w/ its output.

This drops direct graphviz support in favor of built-in 'exec' pipe.