### PR TITLE
Use 'ruff format', instead of 'black'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,13 +72,13 @@ scripts.run = "python -m pytest {args:-vv}"
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["black >= 23.10.1", "ruff >= 0.1.3"]
-scripts.check = ["ruff {args:.}", "black --check --diff {args:.}"]
-scripts.fmt = ["ruff --fix {args:.}", "black {args:.}"]
+dependencies = ["ruff >= 0.1.4"]
+scripts.check = ["ruff {args:.}", "ruff format --check --diff {args:.}"]
+scripts.fmt = ["ruff --fix {args:.}", "ruff format {args:.}"]
 
 [tool.ruff]
 select = ["F", "E", "W", "I", "S", "FBT", "B", "C4", "DTZ", "T10", "ISC", "RET", "SLF", "RUF"]
-ignore = ["S603", "S701", "B904"]
+ignore = ["S603", "S701", "B904", "ISC001"]
 
 [tool.ruff.isort]
 known-first-party = ["holocron"]


### PR DESCRIPTION
Despite being the de facto standard in the community, let's switch from the black formatter to the ruff formatter. The latter is mostly compatible with the former but dozen times faster. So why use many tools if you can use just one?

Since Holocron is a pet project and a great playground for me, let's how far 'ruff format' can get.