### PR TITLE
Ignore feedgen 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "jsonpointer >= 2.3",
     "Markdown >= 3.4",
     "docutils >= 0.19",
-    "feedgen >= 0.9",
+    "feedgen >= 0.9, != 1.0.0",
     "termcolor >= 1.1",
     "colorama >= 0.4",
     "markdown-it-py >= 2.1",


### PR DESCRIPTION
Feedgen 1.0.0 introduced a nasty issue[^1]: only `href` attributes are rendered for `<link>` tags, all other types are completely ignored. We better skip this version until it's fixed. I used feedgen 0.9 for years and faced no critical issues.

[^1]: https://github.com/lkiesow/python-feedgen/issues/135